### PR TITLE
Apply LXQtCompilerSettings to project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
 include(GNUInstallDirs)
 include(LXQtPreventInSourceBuilds)
-include(LXQtCompilerSettings)
+include(LXQtCompilerSettings NO_POLICY_SCOPE)
 include(LXQtTranslateTs)
 include(LXQtTranslateDesktop)
 include(Qt5TranslationLoader)


### PR DESCRIPTION
Without the NO_POLICY_SCOPE we are not really applying the settings.