### PR TITLE
Removed the cause of a huge memory leak

### DIFF
--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -991,6 +991,12 @@ void Proc::refresh()
     SysHistory *s = new SysHistory;
 
     history.append(s);
+
+    if(hprocs)
+    {
+        qDeleteAll(hprocs->begin(), hprocs->end());
+        hprocs->clear();
+    }
     hprocs = &(s->procs);
 
     // init


### PR DESCRIPTION
This patch removes a huge memory leak in `Proc::refresh()`.

NOTE: It may seem that there is still a relatively smaller memory leak in setting the graph as the tray and window icon. However, the increase in memory usage stops after a while. So, this closes https://github.com/lxqt/qps/issues/101