### PR TITLE
Use a smaller pixmap cache

### DIFF
--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -159,6 +159,11 @@ QThread *thread_main = 0;
 
 Qps::Qps()
 {
+    // NOTE: Since we set the graph as the icon continuously,
+    // we do not need a big pixmap cache. The default cache limit
+    // is 10240 KB, which is too much for a reasonable memory usage.
+    QPixmapCache::setCacheLimit(1024);
+
     setObjectName("qps_main_window");
     timer_id = 0;
     field_win = 0;


### PR DESCRIPTION
Because the tray and window icons are set to the graph and the default cache limit may be too big for a continuously changing icon.