### PR TITLE
Drop DEBUG preprocessor definition

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -36,8 +36,6 @@
 #include <QShortcut>
 #include <QPalette>
 
-#define DEBUG qDebug
-//#define DEBUG
 VPointer *vp = NULL; // Temporary
 
 VPointer::VPointer(QWidget *parent) : QWidget(parent)

--- a/src/qps.h
+++ b/src/qps.h
@@ -54,8 +54,6 @@
 #include "prefs.h"
 #include "command.h"
 
-#define DEBUG printf
-
 #define FUNC_START
 #define FUNC_END
 


### PR DESCRIPTION
DEBUG define is not used anywhere now. I'd drop it and use qDebug directly if we need to.