### PR TITLE
A better header

### DIFF
--- a/src/details.cpp
+++ b/src/details.cpp
@@ -653,13 +653,6 @@ void Environ::refresh()
 void Environ::sort_change(int col)
 {
     Procinfo *p = procinfo();
-    /*
-    if(!p->environ) {
-            refresh_environ();
-            if(!p->environ)
-                    return;
-    }*/
-    ////rev = (col == sortedCol()) ? !rev : false;
     setSortedCol(col);
     sort();
     refresh_window();

--- a/src/htable.h
+++ b/src/htable.h
@@ -163,6 +163,9 @@ class TableHead : public QtTableView
     TableHead(HeadedTable *parent = 0);
     virtual bool isCellChanged(int row, int col);
     virtual void checkProfile();
+    void setReveseSort(bool reverse) {
+        reversed_sort = reverse;
+    }
 
   protected slots:
     void scrollSideways(int);
@@ -175,17 +178,16 @@ class TableHead : public QtTableView
     virtual void mouseMoveEvent(QMouseEvent *e);
     virtual void eraseRight(QPainter *, QRect &r);
 
-    virtual void dragEnterEvent(QDragEnterEvent *event);
-    virtual void dragLeaveEvent(QDragLeaveEvent *event);
-
     FloatingHead *floatHead;
 
     HeadedTable *htable; // to access parent class
     QPoint press;
     int click_col; // physical column clicked in
+    bool reversed_sort; // true if sorting backwards
     bool dragging;
     int drag_pos; // previous dragging position
     int drag_offset;
+
 signals:
     void rightClicked(QPoint where, int col);
     void toolTip(QPoint where, int col);
@@ -263,7 +265,7 @@ class HeadedTable : public QWidget
     };
 
     void repaint_changed();
-    int updateColWidth(int col);
+    void updateColWidth(int col);
 
     void resetWidths();
     void resetWidth(int col) { max_widths[col] = -1; } // dont use ?
@@ -362,7 +364,6 @@ signals:
     // Svec<int> widths;		// row widths, indexed by columns
 
     int sorted_col;    // column to emphasize
-    int reversed_sort; // true if sorting backwards
     int options;
     int nrows;
     int ncols;

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -399,11 +399,7 @@ char *Pstable::total_selectedRow(int col)
 Pstable::Pstable(QWidget *parent, Procview *pv) : HeadedTable(parent, 0)
 {
     procview = pv;
-    //	connect(this, SIGNAL(selectionChanged(const Svec<int>
-    //*)),SLOT(selection_update(const Svec<int> *))); //DEL?
-    //	connect(this,
-    // SIGNAL(selectionChanged()),SLOT(selection_update())); //
-    // when procinfo clicked
+
     connect(this, SIGNAL(titleClicked(int)), SLOT(setSortColumn(int)));
     connect(this, SIGNAL(foldSubTree(int)), SLOT(subtree_folded(int)));
     connect(head, SIGNAL(toolTip(QPoint, int)), this,
@@ -412,8 +408,10 @@ Pstable::Pstable(QWidget *parent, Procview *pv) : HeadedTable(parent, 0)
     connect(this, SIGNAL(outOfCell()), SLOT(mouseOutOfCell()));
 }
 
-// who call this ? : from qps.cpp
-void Pstable::setProcview(Procview *pv) { procview = pv; }
+void Pstable::setReveseSort(bool reverse)
+{
+    head->setReveseSort(reverse);
+}
 
 HeadedTable::NodeState Pstable::folded(int row)
 {
@@ -575,29 +573,11 @@ void Pstable::checkTableModel()
 
 void Pstable::refresh()
 {
-    //    qDebug("Pstable:refresh()");
-    //	procview->refresh(); -> move to Qps::refresh()
-    //	qDebug("catsize=%d\n",procview->cats.size());
     procview->rebuild();                       // for Table
     setNumRows(procview->linear_procs.size()); // 1.
     setNumCols(procview->cats.size());         // 2. resetWidths()  UNINITIAL
     kgen = procview->current_gen;
-    // checkTableModel();
     repaint_changed();
-
-    /*
-    if(true)
-    {
-            int count=0,trow=0;
-            for(int row = 0; row < nrows; row++)
-                    if(isSelected(row))
-                    {
-                            count++;
-                            trow=row;
-                    }
-            if (count == 1)
-                    centerVertically(trow);
-    } */
 
     STATUSBAR_SETCOUNT(procview->num_process);
 }

--- a/src/pstable.h
+++ b/src/pstable.h
@@ -33,7 +33,6 @@ class Pstable : public HeadedTable
     Pstable(QWidget *parent, Procview *pv);
 
     void set_sortcol();
-    void setProcview(Procview *pv);
     virtual void moveCol(int col, int place);
     void refresh();
 
@@ -44,6 +43,7 @@ class Pstable : public HeadedTable
     virtual void setSelected(int row, bool sel);
     virtual int totalRow();
     virtual void checkTableModel();
+    void setReveseSort(bool reverse);
 
   public slots:
     // void selection_update(const Svec<int> *row);

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -292,11 +292,7 @@ Qps::Qps()
 /// proclist.append(procview);
 /// procview->start(); // thread start
 
-#ifdef HTABLE2
-    pstable = new Pstable2(this, procview); //
-#else
     pstable = new Pstable(this, procview); // no refresh()
-#endif
     PDisplay *display = new PDisplay(this);
     infobar = display->addSystem(procview);
     //.	infobar = new Infobar(this,procview); // graph_bar
@@ -309,6 +305,9 @@ Qps::Qps()
         set_update_period(1300); // default
         resize(640, 370);        // default initial size
     }
+
+    // apply the kind of sorting that is read by "read_settings()"
+    pstable->setReveseSort(procview->reversed);
 
     set_table_mode(procview->treeview); //  Pstable::refresh() occur
     make_command_menu();                // after qpsrc reading
@@ -1120,17 +1119,14 @@ void Qps::field_added(int field_id)
 //	2. void Qps::menu_remove_field()
 void Qps::field_removed(int index)
 {
-    /// printf("field_removed() index=%d\n",index);
     procview->removeField(index);
     if (procview->treeview and index == F_CMD)
         set_table_mode(false);
-    // should be changed to linear mode !!
 
-    ///	update_menu_status(); // ???
-
-    //	pstable->update();	// no
+    if (context_col == pstable->sortedCol())
+        pstable->setSortedCol(-1); // the sorted column is removed
     pstable->refresh();
-    context_col = -1; // *** important **** : right clicked column removed
+    context_col = -1; // right clicked column is removed
     return;
 }
 

--- a/src/qps.h
+++ b/src/qps.h
@@ -35,18 +35,9 @@
 #include <QSystemTrayIcon>
 #endif
 
-#if QT_VERSION >= 0x040200
-#else
-//#error Qt library version 4.2 or higher is needed for this version of qps
-#endif
-
 #define HTABLE1
 #include "misc.h"
-#ifdef HTABLE2
-#include "pstable2.h"
-#else
 #include "pstable.h"
-#endif
 #include "proc.h"
 #include "infobar.h"
 #include "fieldsel.h"
@@ -283,11 +274,8 @@ class Qps : public QWidget
     void set_load_icon();
 
   public:
-#ifdef HTABLE2
-    Pstable2 *pstable; // test
-#else
     Pstable *pstable;
-#endif
+
     Procview *procview;
     StatusBar *statusBar;
     // Netable *netable;


### PR DESCRIPTION
 (1) Get the needed sizes by consulting the widget style (instead of using hard-coded values and breaking styles).

 (2) Also, instead of making the sort column sunken, use a sort indicator and update it appropriately. After all, a sunken header can't reflect a reverse sorting (and isn't visible with Fusion).

Closes https://github.com/lxqt/qps/issues/162