### PR TITLE
More fixes for the header, especially for its DND

### DIFF
--- a/src/details.cpp
+++ b/src/details.cpp
@@ -131,6 +131,8 @@ QSize SimpleTable::sizeHint() const
 
 QString SimpleTable::title(int col) { return fields[col].name; }
 
+QString SimpleTable::dragTitle(int col) { return fields[col].name; }
+
 int SimpleTable::colWidth(int col) { return fields[col].width; }
 
 inline int SimpleTable::alignment(int col) { return fields[col].align; }

--- a/src/details.h
+++ b/src/details.h
@@ -75,6 +75,7 @@ class SimpleTable : public HeadedTable
 
   protected:
     virtual QString title(int col);
+    virtual QString dragTitle(int col);
     virtual QString text(int row, int col) = 0;
     virtual int colWidth(int col);
     virtual int alignment(int col);

--- a/src/htable.h
+++ b/src/htable.h
@@ -147,10 +147,9 @@ class FloatingHead : public QWidget
     Q_OBJECT
   public:
     FloatingHead(QWidget *parent);
-    QPixmap *pix;
-    void setTitle(QString str, int w, int h);
+    void setTitleAndSize(QString str, int w, int h);
     QString title;
-  protected slots:
+
   protected:
     virtual void paintEvent(QPaintEvent *event);
 };
@@ -183,9 +182,9 @@ class TableHead : public QtTableView
     HeadedTable *htable; // to access parent class
     QPoint press;
     int click_col; // physical column clicked in
+    int right_click_col;
     bool reversed_sort; // true if sorting backwards
     bool dragging;
-    int drag_pos; // previous dragging position
     int drag_offset;
 
 signals:
@@ -277,6 +276,7 @@ class HeadedTable : public QWidget
     void setNumRows(int rows);
     void setNumCols(int cols);
     int clickedColumn() { return head->click_col; }
+    int rightClickedColumn() { return head->right_click_col; }
     void deleteCol(int col, bool update = true);
     int leftCell() { return body->leftCell(); }
     int lastColVisible() { return body->lastColVisible(); }
@@ -313,9 +313,7 @@ signals:
     void foldSubTree(int row);
     void colMoved(int col, int place);
     void flyOnCell(int row, int col);
-    void flyOnHCell(int col);
     void outOfCell();
-    void outOfHCell();
 
   public slots:
     void selectAll();
@@ -325,6 +323,7 @@ signals:
     void fontChange(const QFont &oldFont);
     // These must be implemented in subclasses
     virtual QString title(int col) = 0;
+    virtual QString dragTitle(int col) = 0;
     virtual QString text(int row, int col) = 0;
     virtual char *total_selectedRow(int col);
     // colWidth returns width in digit units; negative means variable width.

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -117,6 +117,17 @@ QString Pstable::title(int col)
     return procview->cats[col]->name;
 }
 
+QString Pstable::dragTitle(int col)
+{
+    if (col >= procview->cats.size()
+        || procview->cats[col]->index == F_CMDLINE
+        || (procview->cats[col]->index == F_PID && procview->treeview))
+    {
+        return ""; // not movable
+    }
+    return procview->cats[col]->name;
+}
+
 // TESTING
 void Pstable::overpaintCell(QPainter *p, int row, int col, int xpos)
 {
@@ -462,14 +473,11 @@ uses
 // 	slot: changes table mode
 void Pstable::setTreeMode(bool treemode)
 {
-    // qDebug("Pstable::setTreeMode() %d , procview.treeview
-    // =%d\n",treemode,procview->treeview);
-    // no more HeadedTable::setTreeMode(treemode);
     HeadedTable::setTreeMode(treemode);
     procview->treeview = treemode;
     procview->fieldArrange();
     set_sortcol();
-    refresh(); //==rebuild();
+    refresh();
 }
 
 //
@@ -491,14 +499,11 @@ bool Pstable::columnMovable(int col)
 //	virtual HeadedTable::moveCol(col,place);
 void Pstable::moveCol(int col, int place)
 {
-    // qDebug("Pstable::moveCol\n");
     procview->moveColumn(col, place);
     set_sortcol(); //???
     procview->fieldArrange();
-    //	update();
     refresh(); // width size changed ,...
     return;
-    // updateColWidth(place); updateColWidth(col);// TEMP
 }
 
 // NEED Check !!

--- a/src/pstable.h
+++ b/src/pstable.h
@@ -57,6 +57,7 @@ class Pstable : public HeadedTable
   protected:
     // implementation of the interface to HeadedTable
     virtual QString title(int col);
+    virtual QString dragTitle(int col);
     virtual QString text(int row, int col);
     virtual int colWidth(int col);
     virtual int alignment(int col);

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -1106,7 +1106,7 @@ void Qps::set_table_mode(bool treemode)
 void Qps::field_added(int field_id)
 {
     int where = -1;
-    where = pstable->clickedColumn();
+    where = pstable->rightClickedColumn() + 1;
     procview->addField(field_id, where);
     pstable->refresh(); // pstable->update(); // repaint
                         // update_menu_status();
@@ -1120,7 +1120,7 @@ void Qps::field_added(int field_id)
 void Qps::field_removed(int index)
 {
     procview->removeField(index);
-    if (procview->treeview and index == F_CMD)
+    if (procview->treeview && index == F_PID)
         set_table_mode(false);
 
     if (context_col == pstable->sortedCol())
@@ -1452,8 +1452,6 @@ void Qps::menu_remove_field()
 {
     if (context_col < 0)
         return;
-    /// printf("cats.size=%d , context_col=%d
-    /// \n",procview->cats.size(),context_col);
     field_removed(procview->cats[context_col]->index);
 }
 

--- a/src/qttableview.cpp
+++ b/src/qttableview.cpp
@@ -913,8 +913,6 @@ void QtTableView::verSbSlidingDone()
 // work?
 void QtTableView::repaintCell(int row, int col, bool usecache) // false
 {
-    //
-    static int c = 0;
     int xPos, yPos;
     if (!colXPos(col, &xPos))
         return;
@@ -922,10 +920,7 @@ void QtTableView::repaintCell(int row, int col, bool usecache) // false
         return;
 
     QRect uR = QRect(xPos, yPos, cellWidth(col), cellHeight(row));
-    // printf("repaintCell() %d,
-    // [%d,%d,%d,%d]\n",c++,uR.x(),uR.y(),uR.width(),uR.height() );
     view->repaint(uR.intersected(viewRect())); // slow
-    // view->update( uR.intersect(viewRect()));
 }
 
 // using
@@ -942,13 +937,6 @@ void QtTableView::repaintRow(int row)
 extern QThread *thread_main;
 void QtTableView::paintEvent(QPaintEvent *e)
 {
-    static int count = 0;
-
-    ////if(thread_main!=thread())
-    ///	printf("Error : main_thread(%X) != paint_thread(%X) report this
-    /// message!!!\n",thread_main,thread());
-
-    /// if ( !isVisible() or !enablePaint )	return;
     checkProfile(); // check cache, current_get
 
     if (!isVisible())
@@ -974,7 +962,6 @@ void QtTableView::paintEvent(QPaintEvent *e)
         return;
     }
 
-    // if ( !rowYPos( firstRow, &yStart ) || !colXPos( firstCol, &xStart ) )
     if (!rowYPos(firstRow, &yStart))
     { // get firstRow
         // printf("eraseRect()\n");
@@ -991,24 +978,14 @@ void QtTableView::paintEvent(QPaintEvent *e)
     int nextX;
     int nextY;
 
-    // printf("frow=%d,fcol=%d\n",firstRow,firstCol);
-    // void 	(QtTableView::*painT)( QPainter *, int row, int col
-    // ,bool
-    // update);
-    // painT=&QtTableView::paintCell;
-    // p.setClipRect( 0,0,viewR.width()-30,viewR.height() ); //enable,
-    // font
-    // not clip
-
     p.setClipRect(viewR); // enable, font not clip (less Qt-4.3.x)
-    // p.setClipRect(updateR); //enable, font not clip
 
-    while (yPos <= maxY and row < nRows)
+    while (yPos <= maxY && row < nRows)
     { // row=...5,6,7....
         nextY = yPos + cellHeight();
         col = firstCol;
         xPos = xStart;
-        while (xPos < maxX and col < nCols)
+        while (xPos < maxX && col < nCols)
         {
             QRect cell;
             int width = cellWidth(col);
@@ -1018,8 +995,6 @@ void QtTableView::paintEvent(QPaintEvent *e)
             tmp_x = xPos;
             {
                 p.translate(xPos, yPos); // (0,0) 	// for subclass
-                //(*this.*painT)( &p, row, col ,
-                // flag_use_cache);
                 paintCell(&p, row, col);
                 p.translate(-xPos, -yPos); // p.translate(0,0);
             }
@@ -1029,10 +1004,6 @@ void QtTableView::paintEvent(QPaintEvent *e)
         row++;
         yPos = nextY;
     }
-
-    //	printf("%s: xoff=%d ,yoff=%d
-    //\n",objectName().toAscii().data(),xOffs,
-    // yOffs);
 
     // while painting we have to erase any areas in the view that
     // are not covered by cells but are covered by the paint event


### PR DESCRIPTION
(1) The command field is always the last section if existing. It can't be dragged.

(2) When the tree is enabled, the PID field is always the first section and can't be dragged. If nonexistent, it'll be created once the tree is enabled. If PID is removed, the tree will be removed too.

(3) Field addition by right clicking is fixed (previously, the position of the new field was incorrect).

NOTE: The header DND isn't very predictable in qps and this patch doesn't include a fix for that.

Closes https://github.com/lxqt/qps/issues/164