### PR TITLE
Made column DND predictable — and much more

### DIFF
--- a/src/proc.h
+++ b/src/proc.h
@@ -811,7 +811,7 @@ class Procview : public Proc
     void fieldArrange();
     void update_customfield();
     //
-    void setSortColumn(int col, bool r = false);
+    void setSortColumn(int col, bool keepSortOrder = false);
     void setTreeMode(bool b);
     void saveCOMMANDFIELD();
 


### PR DESCRIPTION
Closes https://github.com/lxqt/qps/issues/166

Also:

(1) In most process monitors, the downward sort indicator has different meanings for different fields. For example, it means sorting from high to low for CPU and memory, while it shows the alphabetical order for strings (a → z). Qps seems to follow the same rule. Therefore, the default indicator is changed from "SortUp" to "SortDown".

(2) A small mistake is fixed in adding columns. Previously, the PID field would be loaded as the first column with the next startup even if it was moved by DND and there was no tree).

(3) A bug is fixed in column removal. Previously, if the removed column was positioned before the sorted one, sorting would become incorrect until the next session.

NOTE: I think most GUI problems are fixed now.