### PR TITLE
Big patch: Fixed painting of cells, branch lines and...

### DIFF
--- a/src/htable.h
+++ b/src/htable.h
@@ -125,23 +125,6 @@ class TableCache
     }
 };
 
-class VPointer : public QWidget
-{
-    Q_OBJECT
-  public:
-    VPointer(QWidget *parent);
-    QPixmap *pix;
-    QPixmap *pix_vcross;
-    void setMovable(bool b) { flag_movable = b; }
-    bool flag_movable;
-  protected slots:
-    //		void event_cursor_moved(QMouseEvent *e);
-  protected:
-    // virtual void drawButton 3( QPainter * ) ;
-    virtual void paintEvent(QPaintEvent *event);
-    //	void resizeEvent(QResizeEvent *p);
-};
-
 class FloatingHead : public QWidget
 {
     Q_OBJECT
@@ -200,8 +183,6 @@ class TableBody : public QtTableView
   public:
     TableCache tablecache;
     TableBody(HeadedTable *parent = 0);
-    void drawGhostCol(int x, int w);
-    // int zerowidth;		// width of the digit 0
 
     virtual bool isCellChanged(int row, int col);
     virtual void checkProfile();
@@ -226,7 +207,6 @@ class TableBody : public QtTableView
     void timerEvent(QTimerEvent *);
     void updateRow(int row);
     void dragSelectTo(int row);
-    QColor getXorColor();
     HeadedTable *htable; // to access parent class
     int first_drag_row;  // row where drag started
     int prev_drag_row;   // row where drag was at last event
@@ -301,6 +281,7 @@ class HeadedTable : public QWidget
     void selectOnlyOne(int row);
     int numSelected() { return 0; }
     void clearAllSelections();
+    void selectAll();
 
     virtual void setSelected(int row, bool sel){}
     virtual bool isSelected(int row) { return false; }
@@ -316,11 +297,10 @@ signals:
     void outOfCell();
 
   public slots:
-    void selectAll();
     void repaintAll();
 
   protected:
-    void fontChange(const QFont &oldFont);
+    virtual bool event(QEvent *event);
     // These must be implemented in subclasses
     virtual QString title(int col) = 0;
     virtual QString dragTitle(int col) = 0;
@@ -352,6 +332,7 @@ signals:
     int treestep; // indentation for each tree level
 
   private:
+    void fontChange();
     inline int computedWidth(int col);
     int colOffset(int col);
     inline int colXPos(int col);

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -2030,17 +2030,33 @@ void Qps::start_screenshot() {}
 // MOVETO qps::keyPressEvent()
 void SearchBox::keyPressEvent(QKeyEvent *e)
 {
+    // signals
     if (e->key() == Qt::Key_Delete)
     {
         qps->sig_term();
         return;
     }
+    if (e->modifiers() == Qt::AltModifier)
+    {
+        if (e->key() == Qt::Key_H)
+        {
+            qps->sig_hup();
+            return;
+        }
+        if (e->key() == Qt::Key_K)
+        {
+            qps->sig_kill();
+            return;
+        }
+    }
 
     if (e->key() == Qt::Key_Escape)
     {
-        clear(); // clear searchbox
-        qps->pstable->clearAllSelections(); // TEMP
+        clear();
+        qps->pstable->clearAllSelections();
     }
+    else if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_A)
+        qps->pstable->selectAll();
     else
         QLineEdit::keyPressEvent(e);
 

--- a/src/qttableview.cpp
+++ b/src/qttableview.cpp
@@ -911,7 +911,7 @@ void QtTableView::verSbSlidingDone()
   Calls paintCell() for the cells that needs to be repainted.
 */
 // work?
-void QtTableView::repaintCell(int row, int col, bool usecache) // false
+void QtTableView::repaintCell(int row, int col, bool /*usecache*/) // false
 {
     int xPos, yPos;
     if (!colXPos(col, &xPos))
@@ -928,10 +928,7 @@ void QtTableView::repaintRow(int row)
 {
     int y;
     if (rowYPos(row, &y))
-    {
-        // view->repaint(minViewX(),y,viewWidth(),cellHeight());
         view->update(minViewX(), y, viewWidth(), cellHeight());
-    };
 }
 
 extern QThread *thread_main;
@@ -955,16 +952,13 @@ void QtTableView::paintEvent(QPaintEvent *e)
     if (!colXPos(firstCol, &xStart))
     {
         // right empty area of table
-        // p.eraseRect( updateR ); // erase area outside cells but
-        // in view
-        // printf("colXPos null\n");
+        // p.eraseRect( updateR ); // erase area outside cells but in view
         eraseRight(&p, updateR);
         return;
     }
 
     if (!rowYPos(firstRow, &yStart))
     { // get firstRow
-        // printf("eraseRect()\n");
         p.eraseRect(updateR);
         return;
     }
@@ -1014,9 +1008,8 @@ void QtTableView::paintEvent(QPaintEvent *e)
         QRect r = viewR;
         r.setLeft(xPos);
         r.setBottom(yPos < maxY ? yPos : maxY);
-
         // QRect ir=r.intersect( updateR );
-        eraseRight(&p, r); //????????
+        eraseRight(&p, r);
     }
 
     if (yPos <= maxY)
@@ -1043,15 +1036,12 @@ void QtTableView::repaintChanged() // only fullpainting
     if (!colXPos(firstCol, &xStart))
     {
         // right empty area of table
-        printf("b\n");
         view->update(updateR);
         return;
     }
 
-    // if ( !rowYPos( firstRow, &yStart ) || !colXPos( firstCol, &xStart ) )
     if (!rowYPos(firstRow, &yStart))
     { // get firstRow
-        /// printf("a\n");
         view->update(updateR);
         return;
     }
@@ -1084,12 +1074,9 @@ void QtTableView::repaintChanged() // only fullpainting
                 if (col == firstCol)
                 {
                     repaintRow(row); //  speed up!  update()...
-                    //	view->update(minViewX(),y,viewWidth(),cellHeight());
-                    ///	printf("row %d\n",row);
                     break;
                 }
 
-                // printf("row %d col=%d\n",row,col);
                 repaintCell(row, col, false);
             }
             col++;
@@ -1112,39 +1099,13 @@ void QtTableView::repaintChanged() // only fullpainting
         r.setTop(yPos);
         view->repaint(r.intersected(updateR)); // why? CPU +2~3% -> rect.unite()
     }
-
-    return;
-
-    int rows = numRows();
-    int cols = numCols();
-    int left = leftCell(), right = lastColVisible();
-    int top = topCell(), bottom = lastRowVisible();
-
-    if (right >= cols)
-        right = cols - 1; //???
-    if (bottom >= rows)
-        bottom = rows - 1;
-    // if width[col] be changed ,then the right of [col] should be repainted
-    // !
-    // repaintColumns(c,-1);
-    // printf("left=%d \n",left);
-
-    for (int r = top; r <= bottom; r++)
-    {
-        for (int c = left; c <= right; c++)
-        {
-            // if(isCellChanged(r,c)) 	repaintCell(r, c,false);
-        }
-    }
 }
 
-void QtTableView::resizeEvent(QResizeEvent *e)
+void QtTableView::resizeEvent(QResizeEvent* /*e*/)
 {
-    //    printf("QtTableView::resize [%d,%d] \n",width(),height());
     // QAbstractScrollArea::resizeEvent(e);
     updateScrollBars(horValue | verValue | horSteps | horRange | verSteps |
                      verRange);
-    return;
 }
 
 // BOTTLENECK?


### PR DESCRIPTION
Among the fixed issues:

 (1) The tree branch lines are fixed. Previously, they were drawn incorrectly, their texts were positioned badly, and the "windows" style was used for drawing their expanders — something no sensible code should do.

 (2) Cell heights are fixed. Previously, they cut texts with big fonts. Now, they are calculated by the active widget style.

 (3) Background and foreground colors are corrected (the background fix may not be very visible with Fusion or Breeze).

 (4) A cause of crash is removed (previously: start Qps → press `Shift` → click inside the view → crash).

 (5) Activated `Ctrl+A` for selecting all rows, `Alt+H` for hanging up and `Alt+K` for killing processes. They existed before but didn't work.

Closes https://github.com/lxqt/qps/issues/170 and closes https://github.com/lxqt/qps/issues/171 and closes https://github.com/lxqt/qps/issues/172