### PR TITLE
Fixed table size and scrollbars

### DIFF
--- a/src/htable.h
+++ b/src/htable.h
@@ -263,20 +263,12 @@ class HeadedTable : public QWidget
     int topCell() { return body->topCell(); }
     int lastRowVisible() { return body->lastRowVisible(); }
     void updateCell(int row, int col, bool erase = false);
-    void setAutoUpdate(bool update)
-    {
-        head->setAutoUpdate(update);
-        body->setAutoUpdate(update);
-    }
     void centerVertically(int row) { body->centerVertically(row); }
     void showRange(int from, int to) { body->showRange(from, to); }
     void repaintColumns(int col0, int col1 = -1);
     void setTreeMode(bool tm);
     bool treeMode() { return treemode; }
-    int tableWidth() const
-    {
-        return body->totalWidth() + body->verticalScrollBar()->width();
-    }
+    int tableWidth() const;
 
     void selectOnlyOne(int row);
     int numSelected() { return 0; }
@@ -336,7 +328,7 @@ signals:
     inline int computedWidth(int col);
     int colOffset(int col);
     inline int colXPos(int col);
-    void updateCols(int deltacols, int place, bool update);
+    void updateTable();
 
     int alignment_col[64];
     int headwidth_col[64];

--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -523,17 +523,13 @@ void Procview::set_fields_list(int fields[])
     cats.clear();
     for (int i = 0; fields[i] != F_END; i++)
     {
-        if (fields[i] == F_CPUNUM and Proc::num_cpus < 2)
-            continue; // not correctly work
+        if (fields[i] == F_CPUNUM && Proc::num_cpus < 2)
+            continue; // does not work correctly
 
-        Category *c = categories.value(fields[i], NULL);
+        Category *c = categories.value(fields[i], nullptr);
         if (c)
-        {
-            // printf("name=%s\n",c->name);
             cats.append(c);
-        }
     }
-    return;
 }
 
 // return the column number of a field, or -1 if not displayed
@@ -668,7 +664,7 @@ void Procview::moveColumn(int col, int place)
     if (place < col)
         ++col;
     else// if (place > col)
-        place = qMin(place + 1, s - 1);
+        place = qMin(place + 1, s);
     cats.insert(place, cat);
     cats.remove(col);
 }

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -500,8 +500,8 @@ bool Pstable::columnMovable(int col)
 void Pstable::moveCol(int col, int place)
 {
     procview->moveColumn(col, place);
-    set_sortcol(); //???
     procview->fieldArrange();
+    set_sortcol();
     refresh(); // width size changed ,...
     return;
 }
@@ -529,9 +529,7 @@ void Pstable::subtree_folded(int row)
         int r = row + 1;
         while (r < numRows() && procview->linear_procs[r] != nextp)
             r++;
-        //	setAutoUpdate(FALSE);
         showRange(row, r - 1);
-        // setAutoUpdate(TRUE);
     }
     // This is a stopgap solution; it would be better to have htable
     // take care of the hiding of subtrees and repaint only the rows under
@@ -561,8 +559,6 @@ void Pstable::checkTableModel()
         //		printf("Warnning: maybe this is the bug.. wrong!
         //%d
         //%d\n",kgen,procview->current_gen);
-        //		setAutoUpdate(false);  // ********** important for
-        // GUI-thread
         //		HeadedTable::setTreeMode(procview->treeview);
         procview->rebuild();                       // for Table
         setNumRows(procview->linear_procs.size()); // 1.
@@ -570,7 +566,6 @@ void Pstable::checkTableModel()
         //=%d\n",treemode,procview->treeview);
         setNumCols(procview->cats.size()); // 2. resetWidths()
         kgen = procview->current_gen;
-        //		setAutoUpdate(true);
     }
 }
 

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -302,9 +302,9 @@ Qps::Qps()
 
     if (!read_settings())
     {
-        // printf("default value\n");
-        set_update_period(1300); // default
-        resize(640, 370);        // default initial size
+        procview->setSortColumn(procview->findCol(F_CPU)); // default sorted column
+        set_update_period(1300); // default update interval
+        resize(700, 400); // default initial size
     }
 
     // apply the kind of sorting that is read by "read_settings()"

--- a/src/qttableview.h
+++ b/src/qttableview.h
@@ -61,7 +61,6 @@ class QtTableView : public QAbstractScrollArea
     virtual void eraseRight(QPainter *, QRect &r) { return; }
     virtual void checkProfile(){};
     QSize tmp_size; // testing.
-    int tmp_x;
     bool test;
     QColor backColor;
 
@@ -84,7 +83,7 @@ class QtTableView : public QAbstractScrollArea
     int yOffset() const;
     virtual void setXOffset(int);
     virtual void setYOffset(int);
-    virtual void setOffset(int x, int y, bool updateScrBars = true);
+    virtual void setOffset(int x, int y, bool updateScrBars = true, bool scroll = true);
     virtual void scrollTrigger(int x, int y){}; // tmp
 
     virtual int cellWidth(int col);
@@ -99,8 +98,6 @@ class QtTableView : public QAbstractScrollArea
     //    bool	testTableFlags( uint f ) const;
     virtual void setTableFlags(uint f);
     void clearTableFlags(uint f = ~0);
-
-    void setAutoUpdate(bool);
 
     void repaintCell(int row, int column, bool usecache = false);
 
@@ -147,7 +144,7 @@ class QtTableView : public QAbstractScrollArea
     int viewHeight() const;
 
     void updateScrollBars();
-    void updateTableSize();
+    void updateOffsets();
 
     QRect cellUpdateR;
 
@@ -176,8 +173,6 @@ class QtTableView : public QAbstractScrollArea
     uint coveringCornerSquare : 1;
     uint sbDirty : 8;
     uint inSbUpdate : 1;
-
-    bool enablePaint;
 
     uint tFlags;
 };
@@ -228,7 +223,5 @@ inline uint QtTableView::tableFlags() const { return tFlags; }
 // != 0; }
 
 inline QRect QtTableView::cellUpdateRect() const { return cellUpdateR; }
-
-inline void QtTableView::updateScrollBars() { updateScrollBars(0); }
 
 #endif // QTTABLEVIEW_H


### PR DESCRIPTION
 (1) The sizes of the table and its header sections as well as the scrollbar states are updated correctly. Most of the patch is about that.

 (2) The last header section is spread to fill the available space when its contents are left aligned (for a more elegant table).

 (3) Fixed a small mistake in header DND.

 (4) Sorted The CPU column on first run (i.e., when there is no config file yet).

Closes https://github.com/lxqt/qps/issues/176 and closes https://github.com/lxqt/qps/issues/175