### PR TITLE
Don't allow an unsorted table

### DIFF
--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -726,15 +726,10 @@ void Procview::setTreeMode(bool b)
 
 void Procview::setSortColumn(int col, bool keepSortOrder)
 {
-    // qDebug("xxx error? col>=cats.size() %d",col);
-    if (col >= cats.size())
+    if (col < 0 || col >= cats.size()) // restore defaults
     {
-        qDebug("hmmm error? col>=cats.size() %d", col);
-        return;
-    }
-
-    if (col < 0)
-    { // restore defaults
+        if (col >= 0)
+            qDebug("hmmm error? col>=cats.size() %d", col);
         sort_column = -1;
         sortcat = nullptr;
         reversed = false;


### PR DESCRIPTION
In addition to sorting the CPU column by default:

 (1) If a sorted column is removed by the user, sort the first column;

 (2) If the config file is incorrect, sort the CPU column; and

 (3) If the CPU column doesn't exist, sort the first column.

In this way, an unsorted table becomes impossible.

Also, removed the cause of a potential crash with a corrupt config file.

Also, cleaned up the About dialog a little.

Closes https://github.com/lxqt/qps/issues/180 and closes https://github.com/lxqt/qps/issues/178