### PR TITLE
Removed the method `HeadedTable::sizeHintForColumn`

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -1013,25 +1013,22 @@ void HeadedTable::updateColWidth(int col)
     int rows = numRows();
     bool treecol = (treemode && col == 0);
 
-    if ((w = sizeHintForColumn(col)) < 0) // width
+    for (int i = 0; i < rows; i++)
     {
-        if (w < 0)
-            w = -w; // trick.
-
-        for (int i = 0; i < rows; i++)
-        {
-            sw = fontMetrics().width(text(i, col)) + 10;
-
-            if (treecol)
-                sw += treestep * rowDepth(i);
-            if (sw > w)
-                w = sw;
-        }
-
+#if (QT_VERSION >= QT_VERSION_CHECK(5,11,0))
+        sw = fontMetrics().horizontalAdvance(text(i, col)) + 10;
+#else
+        sw = fontMetrics().width(text(i, col)) + 10;
+#endif
         if (treecol)
-        {
-            w += gadget_space;
-        }
+            sw += treestep * rowDepth(i);
+        if (sw > w)
+            w = sw;
+    }
+
+    if (treecol)
+    {
+        w += gadget_space;
     }
 
     // get the header width by consulting the widget style

--- a/src/htable.h
+++ b/src/htable.h
@@ -301,7 +301,6 @@ signals:
     // colWidth returns width in digit units; negative means variable width.
     virtual int colWidth(int col) = 0; // head_width
     virtual int alignment(int col) { return 0; }
-    virtual int sizeHintForColumn(int col) const { return -1; }
     virtual void paintEvent(QPaintEvent *);
     virtual void hideEvent(QHideEvent *event);
     virtual void showEvent(QShowEvent *event);

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -69,43 +69,6 @@ void Pstable::set_sortcol()
     setSortedCol(-1);
 }
 
-// for Optimization
-int Pstable::sizeHintForColumn(int col) const
-{
-    // int aw=fontMetrics().averageCharWidth();
-    int aw = fontMetrics().width("0");
-    int cat_idx = procview->cats[col]->index;
-    // if(col==0) printf("col.idx=%d
-    // %s\n",cat_idx,procview->cats[col]->name);
-    switch (cat_idx)
-    {
-    // 	only COMMON Field
-    //		case F_PID :
-    case F_RSS:
-    case F_SIZE:
-    case F_TTY:
-        return aw * 6;
-    case F_MEM:
-    case F_START:
-    case F_CPU: // PCPU
-        return aw * 6 + 2;
-    case F_TIME:
-        return aw * 5;
-    case F_WCPU:
-    case F_NICE:
-        return aw * 5;
-    case F_CMD:
-        return -(aw * 20);
-
-    case F_USER:
-    //		case F_USER : return aw*10;
-    case F_CMDLINE:
-    default:
-        return -1;
-    }
-    return -1;
-}
-
 // inner
 QString Pstable::title(int col)
 {

--- a/src/pstable.h
+++ b/src/pstable.h
@@ -67,7 +67,6 @@ class Pstable : public HeadedTable
     virtual int parentRow(int row);
     virtual bool lastChild(int row);
     virtual char *total_selectedRow(int col);
-    virtual int sizeHintForColumn(int col) const;
     virtual bool columnMovable(int col);
 
     virtual void overpaintCell(QPainter *p, int row, int col, int xpos);


### PR DESCRIPTION
Because:

 (1) In that method, it was supposed that the character width of an integer can be calculated by replacing all of its digits with `0`. That's incorrect because fonts can have different widths for different characters.

 (2) It was redundant; Qt has a fast method for calculating string lengths.

 (3) We might want to change some integers to floats later (I'll do it soon).