### PR TITLE
Update sort indicator on adding columns

### DIFF
--- a/src/proc.h
+++ b/src/proc.h
@@ -804,7 +804,7 @@ class Procview : public Proc
     void set_fields();
     void set_fields_list(int fields[]);
     void addField(char *name);                   // interface
-    void addField(int FIELD_ID, int where = -1); // base interface
+    int addField(int FIELD_ID, int where = -1); // base interface
     void removeField(int FIELD_ID);
     int findCol(int FIELD_ID);
     void moveColumn(int col, int place);

--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -542,11 +542,13 @@ int Procview::findCol(int field_id)
 }
 
 // basis
+// returns the place where the field is added
+// (-1 if it already exists)
 // called by
 // 	void Procview::fieldArrange();
 // 	qps();
 //
-void Procview::addField(int Fid, int where)
+int Procview::addField(int Fid, int where)
 {
     if (where < 0 || where > cats.size())
     {
@@ -579,7 +581,11 @@ void Procview::addField(int Fid, int where)
 
     Category *newcat = categories[Fid];
     if (cats.indexOf(newcat) < 0) // if not in the list
+    {
         cats.insert(where, newcat);
+        return where;
+    }
+    return -1; // nothings is added
 }
 
 // add a category to last by name

--- a/src/qps.h
+++ b/src/qps.h
@@ -211,13 +211,12 @@ class Qps : public QWidget
     void make_command_menu();
     void view_menu(QAction *);
     void save_quit();
-    void add_fields_menu(int id);
     void add_fields_menu(QAction *act);
 
     void show_popup_menu(QPoint p);
     void context_heading_menu(QPoint p, int col);
 
-    void field_added(int index);
+    void field_added(int index, bool fromContextMenu = false);
     void field_removed(int index);
     void set_table_mode(bool treemode); // hmmm
 


### PR DESCRIPTION
Previously, if a column (field) was added to the left of the sorted column, sorting would become incorrect.

Also:

 (1) Removed a redundant function.

 (2) Fixed the logic of adding/removing fields by using the custom fields dialog. Previously, the context menu column was considered, while it should be ignored when the dialog was used.

Fixes https://github.com/lxqt/qps/issues/188