### PR TITLE
Silenced compiler warnings about QtTableView

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -78,6 +78,7 @@ TableHead::TableHead(HeadedTable *parent)
 
     floatHead = new FloatingHead(parent); // tiny memory leak! don't care.
     floatHead->hide();
+    setLayoutDirection(Qt::LeftToRight); // FIXME: A real fix for RTL is needed!
 }
 
 void TableHead::paintCell(QPainter *p, int /*row*/, int col)
@@ -112,7 +113,7 @@ void TableHead::eraseRight(QPainter* /*p*/, QRect& /*r*/)
 }
 
 // virtual !
-int TableHead::cellWidth(int col) { return htable->max_widths[col]; }
+int TableHead::cellWidth(int col) const { return htable->max_widths[col]; }
 
 //
 void TableHead::scrollSideways(int val) { setXOffset(val); }
@@ -217,6 +218,7 @@ TableBody::TableBody(HeadedTable *parent) : QtTableView(parent), htable(parent)
     autoscrolling = false;
     gadget_click = false;
     setMouseTracking(true);
+    setLayoutDirection(Qt::LeftToRight); // FIXME: A real fix for RTL is needed!
 }
 
 // virtual from QtTableView
@@ -456,11 +458,21 @@ void TableBody::paintCell(QPainter *p, int row, int col)
         p->restore();
 
         gap = x + treestep + 1;
-        align |= Qt::AlignLeft;
+        // FIXME: A real fix for RTL is needed!
+        align |= (htable->layoutDirection() == Qt::RightToLeft ? Qt::AlignRight : Qt::AlignLeft);
     }
     else
     {
-        align |= htable->alignment_col[col];
+        // FIXME: A real fix for RTL is needed!
+        if (htable->layoutDirection() == Qt::RightToLeft)
+        { // reverse the alignment with RTL
+            if (htable->alignment_col[col] == Qt::AlignRight)
+              align |= Qt::AlignLeft;
+            else
+              align |= Qt::AlignRight;
+        }
+        else
+            align |= htable->alignment_col[col];
         if (htable->alignment_col[col] == Qt::AlignRight) // using cache
         {
             w -= gap;
@@ -503,7 +515,7 @@ void TableBody::showRange(int from, int to)
 // virtual
 // called by
 //	1.
-int TableBody::cellWidth(int col) { return htable->max_widths[col]; }
+int TableBody::cellWidth(int col) const { return htable->max_widths[col]; }
 
 // **** fix !!
 void TableBody::updateRow(int row)

--- a/src/htable.h
+++ b/src/htable.h
@@ -154,7 +154,7 @@ class TableHead : public QtTableView
 
   protected:
     virtual void paintCell(QPainter *p, int row, int col);
-    virtual int cellWidth(int col);
+    virtual int cellWidth(int col) const;
     virtual void mousePressEvent(QMouseEvent *e);
     virtual void mouseReleaseEvent(QMouseEvent *e);
     virtual void mouseMoveEvent(QMouseEvent *e);
@@ -197,7 +197,7 @@ class TableBody : public QtTableView
     virtual void scrollTrigger(int x, int y); // tmp
 
     virtual void paintCell(QPainter *p, int row, int col);
-    virtual int cellWidth(int col);
+    virtual int cellWidth(int col) const;
     void mousePressEvent(QMouseEvent *e);
     void mouseDoubleClickEvent(QMouseEvent *e);
     void mouseMoveEvent(QMouseEvent *e);

--- a/src/qttableview.cpp
+++ b/src/qttableview.cpp
@@ -47,7 +47,7 @@ enum ScrollBarDirtyFlags
     horMask = 0xF0
 };
 
-QtTableView::QtTableView(QWidget *parent, const char *name)
+QtTableView::QtTableView(QWidget *parent, const char* /*name*/)
     : QAbstractScrollArea(parent)
 {
     nRows = nCols = 0; // zero rows/cols
@@ -319,11 +319,6 @@ void QtTableView::setOffset(int x, int y, bool updateScrBars, bool scroll)
         updateScrollBars(verValue | horValue);
 }
 
-void QtTableView::scrollContentsBy(int dx, int dy)
-{
-    // view->update() //default
-    // printf("scroll: dx=%d , dy=%d \n",dx,dy);
-}
 /*
   Moves the visible area of the table right by \a xPixels and
   down by \a yPixels pixels.  Both may be negative.
@@ -345,7 +340,7 @@ void QtTableView::scrollContentsBy(int dx, int dy)
 */
 
 // virtual
-int QtTableView::cellWidth(int col) { return cellW; }
+int QtTableView::cellWidth(int /*col*/) const { return cellW; }
 
 /*
   Sets the width in pixels of the table cells to \a cellWidth.
@@ -394,7 +389,7 @@ void QtTableView::setCellWidth(int cellWidth)
   \sa setCellHeight(), cellWidth(), totalHeight()
 */
 
-int QtTableView::cellHeight(int) { return cellH; }
+int QtTableView::cellHeight(int) const { return cellH; }
 
 /*
   Sets the height in pixels of the table cells to \a cellHeight.
@@ -796,8 +791,8 @@ void QtTableView::horSbSliding(int val)
 
 void QtTableView::horSbSlidingDone()
 {
-    if (testTableFlags(Tbl_snapToHGrid) && testTableFlags(Tbl_smoothHScrolling))
-        ; //	snapToGrid( true,  false );
+    //if (testTableFlags(Tbl_snapToHGrid) && testTableFlags(Tbl_smoothHScrolling))
+        //; //	snapToGrid( true,  false );
 }
 
 /*
@@ -853,8 +848,8 @@ void QtTableView::verSbSliding(int val)
 
 void QtTableView::verSbSlidingDone()
 {
-    if (testTableFlags(Tbl_snapToVGrid) && testTableFlags(Tbl_smoothVScrolling))
-        ; // snapToGrid(  false, true );
+    //if (testTableFlags(Tbl_snapToVGrid) && testTableFlags(Tbl_smoothVScrolling))
+        //; // snapToGrid(  false, true );
 }
 
 /*
@@ -1019,7 +1014,6 @@ void QtTableView::repaintChanged() // only fullpainting
             int width = cellWidth(col);
             nextX = xPos + width;
             cell.setRect(xPos, yPos, width, cellH);
-            int ctl = 0;
             tmp_size = viewR.intersected(cell).size();
 
             if (isCellChanged(row, col))
@@ -1066,7 +1060,13 @@ int QtTableView::findRawRow(int yPos, int *cellMaxY, int *cellMinY,
 {
     int r = -1;
     if (nRows == 0)
+    {
+        if (cellMaxY)
+            *cellMaxY = 0;
+        if (cellMinY)
+            *cellMinY = 0;
         return r;
+    }
     if (goOutsideView || (yPos >= minViewY() && yPos <= maxViewY()))
     {
         if (yPos < minViewY())
@@ -1077,6 +1077,10 @@ int QtTableView::findRawRow(int yPos, int *cellMaxY, int *cellMinY,
                      "not supported. (%d,%d)",
                      name("unnamed"), yPos, yOffs);
 #endif
+            if (cellMaxY)
+                *cellMaxY = 0;
+            if (cellMinY)
+                *cellMinY = 0;
             return -1;
         }
         if (cellH)
@@ -1090,15 +1094,14 @@ int QtTableView::findRawRow(int yPos, int *cellMaxY, int *cellMinY,
         }
         else
         { // variable cell height
-            QtTableView *tw = (QtTableView *)this;
             r = yCellOffs;
-            int h = minViewY() - yCellDelta; //##arnt3
+            int h = minViewY() - yCellDelta;
             int oldH = h;
             Q_ASSERT(r < nRows);
             while (r < nRows)
             {
                 oldH = h;
-                h += tw->cellHeight(r); // Start of next cell
+                h += cellHeight(r); // Start of next cell
                 if (yPos < h)
                     break;
                 r++;
@@ -1109,6 +1112,13 @@ int QtTableView::findRawRow(int yPos, int *cellMaxY, int *cellMinY,
                 *cellMinY = oldH;
         }
     }
+    else
+    {
+        if (cellMaxY)
+            *cellMaxY = 0;
+        if (cellMinY)
+            *cellMinY = 0;
+    }
     return r;
 }
 
@@ -1118,7 +1128,13 @@ int QtTableView::findRawCol(int xPos, int *cellMaxX, int *cellMinX,
 {
     int c = -1;
     if (nCols == 0)
+    {
+        if (cellMaxX)
+            *cellMaxX = 0;
+        if (cellMinX)
+            *cellMinX = 0;
         return c;
+    }
     if (goOutsideView || (xPos >= minViewX() && xPos <= maxViewX()))
     {
         if (xPos < minViewX())
@@ -1129,6 +1145,10 @@ int QtTableView::findRawCol(int xPos, int *cellMaxX, int *cellMinX,
                      "not supported. (%d,%d)",
                      name("unnamed"), xPos, xOffs);
 #endif
+            if (cellMaxX)
+                *cellMaxX = 0;
+            if (cellMinX)
+                *cellMinX = 0;
             return -1;
         }
         if (cellW)
@@ -1142,15 +1162,14 @@ int QtTableView::findRawCol(int xPos, int *cellMaxX, int *cellMinX,
         }
         else
         { // variable cell width
-            QtTableView *tw = (QtTableView *)this;
             c = xCellOffs;
-            int w = minViewX() - xCellDelta; //##arnt3
+            int w = minViewX() - xCellDelta;
             int oldW = w;
             Q_ASSERT(c < nCols);
             while (c < nCols)
             {
                 oldW = w;
-                w += tw->cellWidth(c); // Start of next cell
+                w += cellWidth(c); // Start of next cell
                 if (xPos < w)
                     break;
                 c++;
@@ -1160,6 +1179,13 @@ int QtTableView::findRawCol(int xPos, int *cellMaxX, int *cellMinX,
             if (cellMinX)
                 *cellMinX = oldW;
         }
+    }
+    else
+    {
+        if (cellMaxX)
+            *cellMaxX = 0;
+        if (cellMinX)
+            *cellMinX = 0;
     }
     return c;
 }
@@ -1244,10 +1270,9 @@ bool QtTableView::rowYPos(int row, int *yPos) const
             //##arnt3
             y = minViewY() - yCellDelta; // y of leftmost cell in view
             int r = yCellOffs;
-            QtTableView *tw = (QtTableView *)this;
             int maxY = maxViewY();
             while (r < row && y <= maxY)
-                y += tw->cellHeight(r++);
+                y += cellHeight(r++);
             if (y > maxY)
                 return false;
         }
@@ -1288,10 +1313,9 @@ bool QtTableView::colXPos(int col, int *xPos) const
             //##arnt3
             x = minViewX() - xCellDelta; // x of uppermost cell in view
             int c = xCellOffs;
-            QtTableView *tw = (QtTableView *)this;
             int maxX = maxViewX();
             while (c < col && x <= maxX)
-                x += tw->cellWidth(c++);
+                x += cellWidth(c++);
             if (x > maxX)
                 return false;
         }

--- a/src/qttableview.h
+++ b/src/qttableview.h
@@ -57,8 +57,15 @@ class QtTableView : public QAbstractScrollArea
     void coverCornerSquare(bool);
     void clearCache() {}
     void repaintChanged();
-    virtual bool isCellChanged(int r, int c) { return true; };
-    virtual void eraseRight(QPainter *, QRect &r) { return; }
+    virtual bool isCellChanged(int r, int c) {
+        Q_UNUSED(r);
+        Q_UNUSED(c);
+        return true;
+    };
+    virtual void eraseRight(QPainter *, QRect &r) {
+        Q_UNUSED(r);
+        return;
+    }
     virtual void checkProfile(){};
     QSize tmp_size; // testing.
     bool test;
@@ -84,10 +91,13 @@ class QtTableView : public QAbstractScrollArea
     virtual void setXOffset(int);
     virtual void setYOffset(int);
     virtual void setOffset(int x, int y, bool updateScrBars = true, bool scroll = true);
-    virtual void scrollTrigger(int x, int y){}; // tmp
+    virtual void scrollTrigger(int x, int y) {
+        Q_UNUSED(x);
+        Q_UNUSED(y);
+    }; // tmp
 
-    virtual int cellWidth(int col);
-    int cellHeight(int row);
+    virtual int cellWidth(int col) const;
+    int cellHeight(int row) const;
     virtual void setCellWidth(int);
     virtual void setCellHeight(int);
 
@@ -122,7 +132,6 @@ class QtTableView : public QAbstractScrollArea
     virtual void paintCell(QPainter *, int row, int col) = 0;
     virtual void paintEvent(QPaintEvent *);
     virtual void resizeEvent(QResizeEvent *);
-    virtual void scrollContentsBy(int dx, int dy);
 
     int findRow(int yPos) const;
     int findCol(int xPos) const;


### PR DESCRIPTION
Also, "solved" the RTL problem by enforcing an LTR layout on the table and its header. This makes Qps usable with RTL languages for now. A real fix requires deep changes to the code, for which I might have time only later (I added "FIXME" comments to the code as a reminder).

Closes https://github.com/lxqt/qps/issues/190  and closes https://github.com/lxqt/qps/issues/191