### PR TITLE
Fixed memory leak in showing process details dialogs

### DIFF
--- a/src/details.cpp
+++ b/src/details.cpp
@@ -66,16 +66,13 @@ Details::Details(Procinfo *p, Proc *proc) : QWidget(0)
     if (s0.width() > 800)
         s0.setWidth(800);
     resize(s0);
+    setAttribute(Qt::WA_DeleteOnClose, true);
 }
 
 Details::~Details()
 {
-    //	printf("~Details()\n");
     if (pi)
-        pi->detail = 0;
-    int i;
-    /// for(i=0;i<tbar->count();i++)	delete tbar->page(i);
-    delete tbar;
+        pi->detail = nullptr;
 }
 
 void Details::set_procinfo(Procinfo *p)
@@ -111,9 +108,6 @@ void Details::resizeEvent(QResizeEvent *s)
     tbar->resize(s->size()); //**
     QWidget::resizeEvent(s);
 }
-
-// user closed the window (via window manager)
-void Details::closeEvent(QCloseEvent *) { emit closed(this); }
 
 SimpleTable::SimpleTable(QWidget *parent, int nfields, TableField *f,
                          int options)

--- a/src/details.h
+++ b/src/details.h
@@ -50,12 +50,8 @@ class Details : public QWidget
     Proc *proc() { return pr; }
     void set_procinfo(Procinfo *p);
 
-signals:
-    void closed(Details *);
-
   protected:
     virtual void resizeEvent(QResizeEvent *);
-    virtual void closeEvent(QCloseEvent *);
 
   private:
     QTabWidget *tbar;

--- a/src/htable.h
+++ b/src/htable.h
@@ -83,14 +83,17 @@ class TableCache
   public:
     TableCache()
     {
-        // for(int i=0;i<1;i++) // tmp
         rows.append(new TableRow);
         nrow = 0;
         ncol = 0;
     }
 
-    void reset() {} // clear cache
-    void setSize(int row, int col);
+    ~TableCache()
+    {
+        while (rows.size() > 0)
+            delete rows.takeFirst();
+    }
+
     void setRow(int row);
     void setCol(int col);
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -357,6 +357,15 @@ Procinfo::~Procinfo()
             detail = 0;
         }
 
+        qDeleteAll(sock_inodes.begin(), sock_inodes.end());
+        sock_inodes.clear();
+
+        qDeleteAll(fd_files.begin(), fd_files.end());
+        fd_files.clear();
+
+        qDeleteAll(maps.begin(), maps.end());
+        maps.clear();
+
         //    if(environ)    delete environ;
         if (envblock)
             free(envblock); /// double free , SEGFAULT
@@ -1497,6 +1506,10 @@ void Proc::invalidate_sockets() { socks_current = usocks_current = false; }
 // return true if /proc/XX/maps could be read, false otherwise
 bool Procinfo::read_maps()
 {
+    // prevent memory leak
+    qDeleteAll(maps.begin(), maps.end());
+    maps.clear();
+
     // idea: here we could readlink /proc/XX/exe to identify the executable
     // when running 2.0.x
     char name[80];
@@ -1948,7 +1961,22 @@ Proc::Proc()
 
 Proc::~Proc()
 {
-    // killall procinfos
+    if(hprocs)
+    {
+        qDeleteAll(hprocs->begin(), hprocs->end());
+        hprocs->clear();
+    }
+    while (history.size() > 0)
+        delete history.takeFirst();
+
+    qDeleteAll(socks.begin(), socks.end());
+    socks.clear();
+
+    qDeleteAll(usocks.begin(), usocks.end());
+    usocks.clear();
+
+    qDeleteAll(categories.begin(), categories.end());
+    categories.clear();
 }
 
 // COMMON for LINUX,SOLARIS


### PR DESCRIPTION
The serious leak was in `Procinfo::read_maps()`.

Also, details dialogs were never deleted before, so that the more they were opened and closed, the more memory was used. Now, they're deleted on closing.

Fixes https://github.com/lxqt/qps/issues/195