### PR TITLE
Fixed SWAP column

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -317,6 +317,7 @@ Procinfo::Procinfo(Proc *system_proc, int process_id, int thread_id) : refcnt(1)
     stack = 0;
     share = 0;
     mem = 0;
+    swap = 0;
 
     io_read_prev = 0; // **
     io_write_prev = 0;
@@ -831,6 +832,8 @@ int Procinfo::readproc()
             mini_sscanf(buf, "VmStk: %d", &stack); // stack	in kByte
             mini_sscanf(buf, "VmExe: %d", &trs);   // text
         }
+        if (strstr(buf, "VmSwap:"))
+            mini_sscanf(buf, "VmSwap: %d", &swap);   // swap in kByte
     }
 
     /*

--- a/src/proc.h
+++ b/src/proc.h
@@ -100,7 +100,7 @@ enum fields
     F_STACK,
 #endif
     F_SIZE, // VSIZE
-    F_SWAP, // Linux not correct
+    F_SWAP,
     F_MEM,
     F_RSS,
 #ifdef LINUX
@@ -572,6 +572,7 @@ class Procinfo // Process Infomation
     unsigned long
         dt; // dirty pages (number of pages, not K), obsolute in Kernel 2.6
     unsigned long stack; // stack size (K)
+    unsigned long swap;  // swap size (K)
 #endif
 
 #ifdef SOLARIS

--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -200,8 +200,11 @@ QString Cat_swap::string(Procinfo *p)
     // Possible with Linux ?
 
     long sizeK, sizeM;
+#ifdef LINUX
+    sizeK = p->swap;
+#else
     sizeK = p->size > p->resident ? p->size - p->resident : 0;
-
+#endif
     sizeM = sizeK / 1024;
 
     if (sizeM > 0)

--- a/src/proc_linux.cpp
+++ b/src/proc_linux.cpp
@@ -320,6 +320,7 @@ Procinfo::Procinfo(Proc *system_proc, int process_id, int thread_id) : refcnt(1)
     stack = 0;
     share = 0;
     mem = 0;
+    swap = 0;
 
     io_read_prev = 0; // **
     io_write_prev = 0;
@@ -834,6 +835,8 @@ int Procinfo::readproc()
             mini_sscanf(buf, "VmStk: %d", &stack); // stack	in kByte
             mini_sscanf(buf, "VmExe: %d", &trs);   // text
         }
+        if (strstr(buf, "VmSwap:"))
+            mini_sscanf(buf, "VmSwap: %d", &swap);   // swap in kByte
     }
 
     /*


### PR DESCRIPTION
Under Linux, per-process swap usage is shown by `/proc/<PID>/status` → `VmSwap` — `VIRT – RES` was incorrect in the code.

NOTE: "proc_linux.cpp" isn't used but is fixed just for the sake of logic.

Fixes https://github.com/lxqt/qps/issues/187