### PR TITLE
wip: properly save font info

### DIFF
--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -1587,7 +1587,13 @@ bool Qps::read_settings()
     else
         resize(w, h);
 
-    QApplication::setFont(qvariant_cast<QFont>(set.value("font")));
+    QString fontStr = set.value("font").toString();
+    if (!fontStr.isEmpty())
+    {
+        QFont font;
+        font.fromString(fontStr);
+        QApplication::setFont(font);
+    }
 
     // fields
     procview->cats.clear();
@@ -1690,7 +1696,7 @@ void Qps::write_settings() // save setting
     }
     set.setValue("flags", sl);
 
-    set.setValue("font", QApplication::font());
+    set.setValue("font", QApplication::font().toString());
 
     set.setValue("interval", update_period);
 

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -1587,16 +1587,7 @@ bool Qps::read_settings()
     else
         resize(w, h);
 
-    if (set.value("font/name") != QVariant() and
-        set.value("font/size") != QVariant())
-    {
-        QString fname = set.value("font/name").toString();
-        int fsize = set.value("font/size").toInt(); // if not exist then 0
-        QFont font;
-        font.setFamily(fname);
-        font.setPointSize(fsize);
-        QApplication::setFont(font);
-    }
+    QApplication::setFont(qvariant_cast<QFont>(set.value("font")));
 
     // fields
     procview->cats.clear();
@@ -1699,10 +1690,7 @@ void Qps::write_settings() // save setting
     }
     set.setValue("flags", sl);
 
-    set.beginGroup("font");
-    set.setValue("name", QApplication::font().family());
-    set.setValue("size", QApplication::font().pointSize());
-    set.endGroup();
+    set.setValue("font", QApplication::font());
 
     set.setValue("interval", update_period);
 


### PR DESCRIPTION
Some fonts aren't saved when using `font().family()`. This change is basically the way I do it in my applications, it saves all the font info as a QVariant and this works for all fonts that I have tested.

This can be verified with [this font](http://www.bible-researcher.com/hebrew/SBL_Hbrw.ttf). With the old code it won't save the font for next use, but with the new code it will.