### PR TITLE
Fixed IO_R column and IO_W column

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -863,8 +863,10 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);
-        mini_sscanf(buf, "write_bytes:%d", &io_write);
+        mini_sscanf(buf, "read_bytes:%d", &io_read);   // io_read in Byte
+        mini_sscanf(buf, "write_bytes:%d", &io_write); // io_write in Byte
+        io_read /= 1024;
+        io_write /= 1024;
 
         // if(io_read_prev!=0)
         {

--- a/src/proc_linux.cpp
+++ b/src/proc_linux.cpp
@@ -857,8 +857,10 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);
-        mini_sscanf(buf, "write_bytes:%d", &io_write);
+        mini_sscanf(buf, "read_bytes:%d", &io_read);   // io_read in Byte
+        mini_sscanf(buf, "write_bytes:%d", &io_write); // io_write in Byte
+        io_read /= 1024;
+        io_write /= 1024;
 
         // if(io_read_prev!=0)
         {


### PR DESCRIPTION
"read_bytes:" and "write_bytes:" in `/proc/<pid>/io` is Byte.

It was not kByte.
Screenshot is Qps and gnome-system-monitor.

Before:
IO_R size is very large. PID5363 is 323GB(331084.0M).
![IO_R_screen-A](https://user-images.githubusercontent.com/52656419/66450843-f94ad080-ea94-11e9-8c6a-730b194783a8.jpg)

After:
![IO_R_fixed_screen-A](https://user-images.githubusercontent.com/52656419/66450824-e932f100-ea94-11e9-97e8-7ee2e68d51be.jpg)
