### PR TITLE
Fixed IO_R column and IO_W column

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -863,27 +863,31 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);
-        mini_sscanf(buf, "write_bytes:%d", &io_write);
+        unsigned long io_r, io_w;
+        mini_sscanf(buf, "read_bytes:%lu", &io_r);  // io_r in Byte
+        mini_sscanf(buf, "write_bytes:%lu", &io_w); // io_w in Byte
+        io_read = io_r / 1024;
+        io_write = io_w / 1024;
 
         // if(io_read_prev!=0)
         {
             if (io_read_prev == 0)
-                io_read_prev = io_read;
+                io_read_prev = io_r;
             if (io_write_prev == 0)
-                io_write_prev = io_write;
+                io_write_prev = io_w;
 
-            // NOTE: Kbps right????
-            io_read_KBps = (io_read - io_read_prev) /
+            // NOTE: Kbps = byte / (msec / 1000) / 1024    // accurate
+            //       Kbps = (byte / 1024) / (msec / 1024)  // not accurate
+            io_read_KBps = (io_r - io_read_prev) /
                            proc->update_msec; // not accurate....
-            io_write_KBps = (io_write - io_write_prev) / proc->update_msec;
+            io_write_KBps = (io_w - io_write_prev) / proc->update_msec;
 
             proc->io_byte += io_read_KBps; // test
             proc->io_byte += io_write_KBps;
         }
 
-        io_read_prev = io_read;
-        io_write_prev = io_write;
+        io_read_prev = io_r;
+        io_write_prev = io_w;
 
         // io_read>>=10; //  divide by 1024
         // io_write>>=10; //  divide by 1024

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -863,10 +863,8 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);   // io_read in Byte
-        mini_sscanf(buf, "write_bytes:%d", &io_write); // io_write in Byte
-        io_read /= 1024;
-        io_write /= 1024;
+        mini_sscanf(buf, "read_bytes:%d", &io_read);
+        mini_sscanf(buf, "write_bytes:%d", &io_write);
 
         // if(io_read_prev!=0)
         {

--- a/src/proc.h
+++ b/src/proc.h
@@ -540,11 +540,11 @@ class Procinfo // Process Infomation
     unsigned long cmajflt;
 #endif
 
-    unsigned long io_read;       // byte, testing
-    unsigned long io_write;      // testing
+    unsigned long io_read;       // K byte, testing
+    unsigned long io_write;      // K byte, testing
     unsigned long io_read_KBps;  // K byte/sec
     unsigned long io_write_KBps; // K byte/sec
-    unsigned long io_read_prev, io_write_prev;
+    unsigned long io_read_prev, io_write_prev; // byte
 
     unsigned long flags; //?
     unsigned long minflt;

--- a/src/proc_linux.cpp
+++ b/src/proc_linux.cpp
@@ -857,10 +857,8 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);   // io_read in Byte
-        mini_sscanf(buf, "write_bytes:%d", &io_write); // io_write in Byte
-        io_read /= 1024;
-        io_write /= 1024;
+        mini_sscanf(buf, "read_bytes:%d", &io_read);
+        mini_sscanf(buf, "write_bytes:%d", &io_write);
 
         // if(io_read_prev!=0)
         {

--- a/src/proc_linux.cpp
+++ b/src/proc_linux.cpp
@@ -857,27 +857,31 @@ int Procinfo::readproc()
     {
         // rchar = ... not file maybe sockread
         //
-        mini_sscanf(buf, "read_bytes:%d", &io_read);
-        mini_sscanf(buf, "write_bytes:%d", &io_write);
+        unsigned long io_r, io_w;
+        mini_sscanf(buf, "read_bytes:%lu", &io_r);  // io_r in Byte
+        mini_sscanf(buf, "write_bytes:%lu", &io_w); // io_w in Byte
+        io_read = io_r / 1024;
+        io_write = io_w / 1024;
 
         // if(io_read_prev!=0)
         {
             if (io_read_prev == 0)
-                io_read_prev = io_read;
+                io_read_prev = io_r;
             if (io_write_prev == 0)
-                io_write_prev = io_write;
+                io_write_prev = io_w;
 
-            // NOTE: Kbps right????
-            io_read_KBps = (io_read - io_read_prev) /
+            // NOTE: Kbps = byte / (msec / 1000) / 1024    // accurate
+            //       Kbps = (byte / 1024) / (msec / 1024)  // not accurate
+            io_read_KBps = (io_r - io_read_prev) /
                            proc->update_msec; // not accurate....
-            io_write_KBps = (io_write - io_write_prev) / proc->update_msec;
+            io_write_KBps = (io_w - io_write_prev) / proc->update_msec;
 
             proc->io_byte += io_read_KBps; // test
             proc->io_byte += io_write_KBps;
         }
 
-        io_read_prev = io_read;
-        io_write_prev = io_write;
+        io_read_prev = io_r;
+        io_write_prev = io_w;
 
         // io_read>>=10; //  divide by 1024
         // io_write>>=10; //  divide by 1024


### PR DESCRIPTION
I revert #201. Then I fix it again.  
`io_read_prev` and `io_write_prev` are Byte.
I overlooked this. I am sorry.

"read_bytes:" and "write_bytes:" in `/proc/<pid>/io` are Byte.  
It was not KByte.  
```
io_read, io_write           : KByte
io_read_prev, io_write_prev : Byte
```

Screenshot is Qps and gnome-system-monitor.

Before(Latest git):
IO graph is small.
![IO_Graph_screen_A](https://user-images.githubusercontent.com/52656419/66700770-96289a80-ed2f-11e9-94bd-bf7bccf45481.jpg)

Revert "Fixed IO_R column and IO_W column":
IO_R size and IO_W size are very large.
![IO_R_W_screen_A](https://user-images.githubusercontent.com/52656419/66700772-9cb71200-ed2f-11e9-840f-f8f00cd27d10.jpg)

After:
![IO_R_W_Fix_screen_A](https://user-images.githubusercontent.com/52656419/66700777-ac365b00-ed2f-11e9-9737-0930c89cd65d.jpg)

Distribution & Version: Ubuntu 18.04.3 LTS (i686)  
Kernel: 4.15.0-65-generic
