### PR TITLE
Drop C deprecated headers

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -20,9 +20,9 @@
  * MA 02110-1301, USA.
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
 
 #include <QMessageBox>
 

--- a/src/details.cpp
+++ b/src/details.cpp
@@ -20,7 +20,7 @@
  * MA 02110-1301, USA.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <netdb.h>
 #include <netinet/in.h>
 

--- a/src/infobar.cpp
+++ b/src/infobar.cpp
@@ -20,9 +20,9 @@
  * MA 02110-1301, USA.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <sys/types.h>
-#include <time.h>
+#include <ctime>
 
 #include "infobar.h"
 #include "proc.h"

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -22,12 +22,12 @@
 
 // This module implements asynchronous address->hostname lookup.
 
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <signal.h>
+#include <csignal>
 #include <netinet/in.h>
 #include <netdb.h>
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -33,9 +33,9 @@ extern bool flag_devel;
 #include "../icon/x1.xpm"
 #include "../icon/x2.xpm"
 
-#include <stdio.h>
-#include <time.h>
-#include <errno.h>
+#include <cstdio>
+#include <ctime>
+#include <cerrno>
 
 // 300% faster than glibc (by fasthyun@magicn.com)
 int x_atoi(const char *sstr)
@@ -64,8 +64,8 @@ QWidget *getQpsWidget()
     return nullptr;
 }
 
-#include <stdarg.h>
-#include <string.h>
+#include <cstdarg>
+#include <cstring>
 /*
   ver 0.2
   A simplified vsscanf implementation from Internet

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -28,15 +28,15 @@
         TGID thread group leader's pid
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <dirent.h>
 #include <fcntl.h>
-#include <time.h>
+#include <ctime>
 
 #include <sched.h>  // sched_rr_get_interval(pid, &ts);
 #include <libgen.h> // basename()

--- a/src/qps.cpp
+++ b/src/qps.cpp
@@ -45,15 +45,15 @@
 
 #include "../icon/icon.xpm"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/utsname.h> // uname
-#include <signal.h>
-#include <errno.h>
+#include <csignal>
+#include <cerrno>
 #include <sched.h>
 #include <unistd.h> //for sleep
 
@@ -1790,7 +1790,7 @@ void Qps::clicked_trayicon(QSystemTrayIcon::ActivationReason r)
     }
 }
 
-#include <signal.h>
+#include <csignal>
 void signal_handler(int /*sig*/)
 {
     qps->save_quit();

--- a/src/ttystr.cpp
+++ b/src/ttystr.cpp
@@ -20,9 +20,9 @@
  * MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/types.h> //major() minor()
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/uidstr.cpp
+++ b/src/uidstr.cpp
@@ -23,9 +23,9 @@
 #include <pwd.h>
 #include <grp.h>
 #include <sys/types.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 #include "uidstr.h"
 

--- a/src/wchan.cpp
+++ b/src/wchan.cpp
@@ -20,9 +20,9 @@
  * MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 #include <sys/utsname.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
They are deprecated in C++. Just use the C++ ones.
Done by clang-tidy.