### PR TITLE
Made config file independent of translation

### DIFF
--- a/src/proc.h
+++ b/src/proc.h
@@ -864,9 +864,9 @@ class Procview : public Proc
 
     int idxF_CMD; ////Test
     QStringList customfields;
+    QList<QVariant> customFieldIDs;
     static int custom_fields[64];
     // lists of fields to be used for different views, terminated by -1:
-    static int mini_fields[]; // for mobile
     static int basic_fields[];
     static int jobs_fields[];
     static int mem_fields[];

--- a/src/proc_common.cpp
+++ b/src/proc_common.cpp
@@ -45,9 +45,6 @@ bool Procview::flag_show_file_path = false;
 bool Procview::flag_cumulative = false;  // times cumulative with children's
 bool Procview::flag_pcpu_single = false; // %CPU= pcpu/num_cpus
 
-// COMMON: basic field
-int Procview::mini_fields[] = {F_PID, F_STAT, F_MEM, F_CPU, F_CMDLINE, F_END};
-
 // COMMON?
 // return username from /etc/passwd
 const QString userName(int uid, int euid)
@@ -609,31 +606,13 @@ void Procview::removeField(int field_id)
 //	DEL? -> not yet
 void Procview::update_customfield()
 {
-    int i;
-    //	printf("update custom_fields\n");
-
     customfields.clear();
 
-    for (i = 0; i < cats.size(); i++)
-        customfields.append(cats[i]->name);
-
-    // DEL
-    if (false and treeview)
+    for (int i = 0; i < cats.size(); i++)
     {
-        int idx = customfields.indexOf("COMMAND"); // == removeField(F_CMD);
-        if (idx >= 0)
-            customfields.removeAt(idx);
-
-        if (idxF_CMD >= 0)
-        {
-            /* if(customfields.size()<=idxF_CMD)
-                    customfields.append(categories[F_CMD]->name);
-            else	*/
-            customfields.insert(idxF_CMD, categories[F_CMD]->name);
-        }
+        customfields.append(cats[i]->name);
+        customFieldIDs.append(cats[i]->id);
     }
-
-    return;
 }
 
 // Description : FIELD movement by mouse drag


### PR DESCRIPTION
To do that, field IDs are used instead of their (translated) names.

NOTE: The settings will be partially reset after applying this patch because the new values aren't compatible with the old ones. I could have added a few lines for backward compatibility but I don't think it's worth the extra code; these things aren't unexpected with upgrades.

Closes https://github.com/lxqt/qps/issues/224