### PR TITLE
Avoid temporary heap allocations

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -129,12 +129,12 @@ QString substString(QString str, Procinfo *p)
         int v = str.indexOf('%', i);
         if (v < 0)
         {
-            s.append(str.right(len - i));
+            s.append(str.rightRef(len - i));
             break;
         }
         else
         {
-            s.append(str.mid(i, v - i));
+            s.append(str.midRef(i, v - i));
             if (++v >= len)
                 break;
             QString subst;

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -125,7 +125,7 @@ void IntervalDialog::event_label_changed()
     while ((s[i] >= '0' && s[i] <= '9') || s[i] == '.')
         i++;
 
-    float period = (i > 0) ? s.left(i).toFloat() : -1;
+    float period = (i > 0) ? s.leftRef(i).toFloat() : -1;
 
     s = s.mid(i, 3).simplified();
     if (s.length() == 0 || s == "s")
@@ -156,7 +156,7 @@ void IntervalDialog::done_dialog()
     while ((s[i] >= '0' && s[i] <= '9') || s[i] == '.')
         i++;
 
-    float period = (i > 0) ? s.left(i).toFloat() : -1;
+    float period = (i > 0) ? s.leftRef(i).toFloat() : -1;
 
     s = s.mid(i, 3).simplified();
     if (s.length() == 0 || s == "s")


### PR DESCRIPTION
Use QString::fooRef() instead of QString::foo().