### PR TITLE
Avoid overflow in proc.cpp

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -2400,7 +2400,7 @@ bool Procinfo::read_fds()
             continue; // skip . and ..
         int fdnum = atoi(e->d_name);
         strcpy(str, path);
-        strcat(str, e->d_name);
+        strncat(str, e->d_name, 128 - strlen(str));
         //	printf("str=%s\n",str);
         read_fd(fdnum, str);
     }

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -2400,7 +2400,7 @@ bool Procinfo::read_fds()
             continue; // skip . and ..
         int fdnum = atoi(e->d_name);
         strcpy(str, path);
-        strncat(str, e->d_name, 128 - strlen(str));
+        strncat(str, e->d_name, 128 - 1 - strlen(str));
         //	printf("str=%s\n",str);
         read_fd(fdnum, str);
     }


### PR DESCRIPTION
I'm not sure if it should make a serious concern, but it's better safe than sorry