### PR TITLE
Get rid of sched_getaffinity hack

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -97,27 +97,6 @@ enum
     SSDISCONNECTING /* in process of disconnecting	*/
 };
 
-#define QPS_SCHED_AFFINITY ok
-
-#ifdef QPS_SCHED_AFFINITY
-#ifndef SYS_sched_setaffinity
-#define SYS_sched_setaffinity 241
-#endif
-#ifndef SYS_sched_getaffinity
-#define SYS_sched_getaffinity 242
-#endif
-
-// Needed for some glibc
-int qps_sched_setaffinity(pid_t pid, unsigned int len, unsigned long *mask)
-{
-    return syscall(SYS_sched_setaffinity, pid, len, mask);
-}
-int qps_sched_getaffinity(pid_t pid, unsigned int len, unsigned long *mask)
-{
-    return syscall(SYS_sched_getaffinity, pid, len, mask);
-}
-#endif
-
 /*
    Thread Problems.
    pthread_exit()
@@ -2262,14 +2241,9 @@ double Procinfo::get_tms()
 
 unsigned long Procinfo::get_affcpu()
 {
-#ifdef QPS_SCHED_AFFINITY
-    if (qps_sched_getaffinity(pid, sizeof(unsigned long), &affcpu) == -1)
-        affcpu = (unsigned long)0;
-#else
     if (sched_getaffinity(pid, sizeof(unsigned long), (cpu_set_t *)&affcpu) ==
         -1)
         affcpu = (unsigned long)0;
-#endif
     return affcpu;
 }
 


### PR DESCRIPTION
sched_getaffinity is available on all supported linux systems (at least glibc and musl on Linux are fine)
On the other systems (like Darwin) this syscall is not available anyway. I am not sure if this affects *BSD.
This hack seems to be written for some ancient versions of glibc right after Linux 2.5.8 was out, so I see no reason to keep it. 