### PR TITLE
Fixed a crash when starting minimized to tray

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -111,11 +111,11 @@ enum
 int qps_sched_setaffinity(pid_t pid, unsigned int len, unsigned long *mask)
 {
     return syscall(SYS_sched_setaffinity, pid, len, mask);
-};
+}
 int qps_sched_getaffinity(pid_t pid, unsigned int len, unsigned long *mask)
 {
     return syscall(SYS_sched_getaffinity, pid, len, mask);
-};
+}
 #endif
 
 /*

--- a/src/qps.h
+++ b/src/qps.h
@@ -176,7 +176,6 @@ class Qps : public QWidget
 
   public slots:
     void clicked_trayicon(QSystemTrayIcon::ActivationReason);
-    void clicked_trayicon();
     void sig_term();
     void sig_hup();
     void sig_stop();
@@ -221,6 +220,7 @@ class Qps : public QWidget
 
     void update_timer();
     void refresh();
+    void showWindow();
     void test_popup(const QUrl &link);
     void update_menu_status();
 

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -30,72 +30,28 @@
 
   */
 
-#include <QApplication> // *****should be First!!!
 #include "global.h"     // Qps *qps;
 #include "trayicon.h"
 
-#include <QMouseEvent>
-#include <QDesktopWidget>
-#include <QPainter>
-#include <QToolTip>
-
-// QIcon icon = iconComboBox->itemIcon(index);
-//   trayIcon->setIcon(icon);
-
-//----------------------------------------------------------------------------
-// common stuff
-//----------------------------------------------------------------------------
-// for Gnome2 Notification Area
-
 extern bool flag_xcompmgr;
 
-#define SYSTEM_TRAY_REQUEST_DOCK 0
-#define SYSTEM_TRAY_BEGIN_MESSAGE 1
-#define SYSTEM_TRAY_CANCEL_MESSAGE 2
-
 TrayIcon::TrayIcon(const QPixmap &icon, const QString &tooltip, QMenu *popup,
-                   QWidget * /*parent*/, const char * /*name*/)
-    : QSystemTrayIcon(nullptr /* shoud be NULL!! */), pop(popup), pm(icon),
-      tip(tooltip)
+                   QWidget *parent)
+    : QSystemTrayIcon(parent),
+      pm(icon)
 {
-    flag_show_tip = false;
-    flag_systray_ready = false;
-    inTray = false;
-    isWMDock = false;
-
     QSystemTrayIcon::setIcon(icon);
     QSystemTrayIcon::setContextMenu(popup);
+    QSystemTrayIcon::setToolTip(tooltip);
 
     if (!pm.width() || !pm.height())
         pm = QPixmap(45, 45);
     hasSysTray = QSystemTrayIcon::isSystemTrayAvailable();
 }
 
-/*!
-  Removes the icon from the system tray and frees all allocated resources.
-*/
-TrayIcon::~TrayIcon() { sysRemove(); }
-
-/*!
-  Sets the context menu to \a popup. The context menu will pop up when the
-  user clicks the system tray entry with the right mouse button.
-*/
-void TrayIcon::setPopup(QMenu *popup) { pop = popup; }
-
-/*!
-  Returns the current popup menu.
-*/
-QMenu *TrayIcon::popup() const { return pop; }
+TrayIcon::~TrayIcon() {}
 
 QPixmap TrayIcon::icon() const { return pm; }
-
-//----------------------------------------------------------------------------
-// TrayIcon
-//----------------------------------------------------------------------------
-// DRAFT Code (by fasthyun@magicn.com)
-void TrayIcon::init_TrayIconFreeDesktop() {}
-
-void TrayIcon::init_WindowMakerDock() {}
 
 void TrayIcon::sysInstall()
 {
@@ -103,15 +59,6 @@ void TrayIcon::sysInstall()
     {
         show();
     }
-}
-
-
-void TrayIcon::sysRemove()
-{
-    // printf("Qps: sysRemove\n");
-    inTray = false;
-    /// boolSysTray=isWMDock=false;
-    hide();
 }
 
 /*!
@@ -125,129 +72,3 @@ void TrayIcon::setIcon(const QPixmap &pix)
         return;
     pm = pix;
 }
-
-/*!
-  \property TrayIcon::toolTip
-  \brief the tooltip for the system tray entry
-
-  On some systems, the tooltip's length is limited and will be truncated as
-  necessary.
-*/
-void TrayIcon::setToolTip(const QString &tooltip)
-{
-    if (pop->isVisible())
-        flag_show_tip = false;
-    if (flag_show_tip)
-        QToolTip::showText(tip_pos, tooltip);
-    else
-        QToolTip::hideText();
-    tip = tooltip;
-}
-
-void TrayIcon::leaveEvent(QEvent *) { flag_show_tip = false; }
-
-void TrayIcon::mouseMoveEvent(QMouseEvent *e)
-{
-    // printf("move\n");
-    // QToolTip::showText(QPoint(0,0),"" );
-    // QToolTip::showText(e->globalPos(),tip );
-    tip_pos = e->globalPos();
-    flag_show_tip = true;
-    QToolTip::showText(tip_pos, tip);
-    e->accept();
-}
-
-void TrayIcon::mousePressEvent(QMouseEvent *e)
-{
-    // test_xapp();
-    // This is for X11, menus appear on mouse press
-    // I'm not sure whether Mac should be here or below.. Somebody check?
-    switch (e->button())
-    {
-    case Qt::RightButton:
-        if (pop)
-        {
-            pop->popup(e->globalPos());
-            e->accept();
-        }
-        break;
-    case Qt::LeftButton:
-    case Qt::MidButton:
-        // emit clicked( e->globalPos(), e->button() );
-        emit clicked(e->globalPos());
-    default:
-        break;
-    }
-    e->ignore();
-}
-
-void TrayIcon::mouseReleaseEvent(QMouseEvent *e)
-{
-    //	printf("mouseReleaseEvent\n");
-    switch (e->button())
-    {
-    case Qt::RightButton:
-        if (pop)
-        {
-            // Necessary to make keyboard focus
-            // and menu closing work on Windows.
-            //	e->accept();
-        }
-        break;
-    case Qt::LeftButton:
-    case Qt::MidButton:
-        // emit clicked( e->globalPos(), e->button() );
-        // emit clicked( e->globalPos());
-        break;
-    default:
-        break;
-    }
-    e->ignore();
-}
-
-void TrayIcon::mouseDoubleClickEvent(QMouseEvent *e)
-{
-    if (e->button() == Qt::LeftButton)
-        emit doubleClicked(e->globalPos());
-    e->accept();
-}
-
-// this will be called  before shown !!
-void TrayIcon::paintEvent(QPaintEvent *)
-{
-    /*
-    //printf("paintEvent()\n");
-    QPainter p(this);
-    int w,h;
-    if(isVisible()==false) // ** important to prevent X11 Error !!
-    {
-    //	printf("paintEvent(): hidden\n");
-            return;
-    }
-    w=width()/2 ;
-    h=height()/2;
-    p.drawPixmap(w - pm.width()/2, h - pm.height()/2, pm); */
-}
-
-// for session logout ?? never called
-void TrayIcon::closeEvent(QCloseEvent *e)
-{
-    printf("TrayIcon::closeEvent()\n");
-    e->accept();
-}
-
-// called after size changed
-void TrayIcon::resizeEvent(QResizeEvent * /*e*/)
-{
-    /// int w, h;
-    // printf("TrayIcon::resizeEvent(): w=%d,h=%d\n",width(),height());
-    // if(isVisible()==false) return;  // X11 error !!
-    /// w=width();h=height();
-    if (isWMDock)
-    {
-        /// w=w-14;h=h-14;
-    }
-    // qps->setIconSize(w,h);
-}
-
-void QPS_SHOW();

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -37,65 +37,21 @@ class TrayIcon : public QSystemTrayIcon
 {
     Q_OBJECT
   public:
-    TrayIcon(const QPixmap &, const QString &, QMenu *popup = nullptr,
-             QWidget *parent = nullptr, const char *name = nullptr);
+    TrayIcon(const QPixmap &icon, const QString &tooltip, QMenu *popup = nullptr,
+             QWidget *parent = nullptr);
     ~TrayIcon() override;
 
-    // use WindowMaker dock mode.  ignored on non-X11 platforms
-    void setWMDock(bool use) { isWMDock = use; }
-    bool checkWMDock() { return isWMDock; }
     bool hasSysTray;
-    void setSysTray(bool /*val*/)
-    { // boolSysTray=val;
-    }
-
-    // Set a popup menu to handle RMB
-    void setPopup(QMenu *);
-    QMenu *popup() const;
 
     QPixmap icon() const;
 
     void sysInstall();
-    void sysRemove();
-
-    void init_TrayIconFreeDesktop();
-    void init_WindowMakerDock();
 
   public slots:
     void setIcon(const QPixmap &icon);
-    void setToolTip(const QString &tip);
-signals:
-    void clicked(const QPoint &);
-    void clicked(const QPoint &, int);
-    void doubleClicked(const QPoint &);
-    void closed();
-
-  protected:
-    //	bool event( QEvent *e );
-    virtual void mouseMoveEvent(QMouseEvent *e);
-    virtual void mousePressEvent(QMouseEvent *e);
-    virtual void mouseReleaseEvent(QMouseEvent *e);
-    virtual void mouseDoubleClickEvent(QMouseEvent *e);
-    virtual void leaveEvent(QEvent *);
-
-    void paintEvent(QPaintEvent *);
-    void resizeEvent(QResizeEvent *e);
-    //	void hideEvent ( QHideEvent *e ); // called after hide()
-    void closeEvent(QCloseEvent *e);
 
   private:
-    QMenu *pop;
     QPixmap pm;
-    QString tip;
-    QPoint tip_pos;
-
-    bool isWMDock;
-    //	bool boolSysTray; //DEL?
-    bool inTray;
-    bool flag_systray_ready;
-    bool flag_show_tip;
-
-    // DEL void sysUpdateToolTip();
 };
 
 #endif // CS_TRAYICON_H


### PR DESCRIPTION
Fixes https://github.com/lxqt/qps/issues/258

I also removed several redundant methods of the class `TrayIcon`. I don't know why the original author thought that, for example, `QSystemTrayIcon` had the method `mousePressEvent()` — maybe it was a `QWidget` with Qt2!