### PR TITLE
Ensure that only one sort indicator exists

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -888,7 +888,12 @@ int HeadedTable::tableWidth() const
 // update table Head !!
 void HeadedTable::setSortedCol(int col)
 {
+    int old_sorted_col = sorted_col;
     sorted_col = col;
+    // repaint the previously sorted header section to make sure that
+    // its sort indicator is removed (see QtTableView::repaintCell())
+    if (old_sorted_col != sorted_col && old_sorted_col > -1 && old_sorted_col < ncols)
+        head->repaintCell(0, old_sorted_col);
 }
 
 // should be virtual. why?


### PR DESCRIPTION
Previously and under certain circumstances, it was possible that 2 sort indicators were shown on the header, although the wrong one might be removed with a GUI update.

Fixes https://github.com/lxqt/qps/issues/324