### PR TITLE
Removed a redundant function

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -840,34 +840,6 @@ inline int HeadedTable::colXPos(int col)
     return x;
 }
 
-// repaint columns from col0 to col1. If col1 is -1, repaint all
-// the way to the right edge of the table.
-// called by
-//          1.void Qps::update_table(int col)
-void HeadedTable::repaintColumns(int col0, int col1)
-{
-    QRect bvr = body->viewRect();
-    QRect hvr = head->viewRect();
-    int x0 = colOffset(col0) - body->xOffset();
-    if (x0 > hvr.width())
-        return;
-    if (x0 < 0)
-        x0 = 0;
-    bvr.setLeft(x0);
-    hvr.setLeft(x0);
-    if (col1 >= 0)
-    {
-        int x1 = colOffset(col1) + max_widths[col1] - body->xOffset();
-        if (x1 < hvr.width())
-        {
-            hvr.setRight(x1);
-            bvr.setRight(x1);
-        }
-    }
-    head->repaint(hvr);
-    body->repaint(bvr);
-}
-
 // DEL -> virtual
 // 	called by Pstable::setTreeMode(bool)
 void HeadedTable::setTreeMode(bool tm)

--- a/src/htable.h
+++ b/src/htable.h
@@ -266,7 +266,6 @@ class HeadedTable : public QWidget
     void updateCell(int row, int col, bool erase = false);
     void centerVertically(int row) { body->centerVertically(row); }
     void showRange(int from, int to) { body->showRange(from, to); }
-    void repaintColumns(int col0, int col1 = -1);
     void setTreeMode(bool tm);
     bool treeMode() { return treemode; }
     int tableWidth() const;


### PR DESCRIPTION
The method `HeadedTable::repaintColumns()` was not only redundant but also without effect if used (`QtTableView::repaintCell()` should have been used if needed).