### PR TITLE
Remove redundant semicolon

### DIFF
--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -41,7 +41,7 @@
 char *Lookup::argv0;
 int Lookup::maxtitlelen;
 
-UintQueue::UintQueue() { first = last = 0; };
+UintQueue::UintQueue() { first = last = 0; }
 
 void UintQueue::enqueue(unsigned x)
 {


### PR DESCRIPTION
Nothing special, just getting rid of a compiler warning. Most likely safe.