### PR TITLE
Specify the widget when showing its tooltip (on Wayland)

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -170,7 +170,7 @@ void TableHead::mouseMoveEvent(QMouseEvent *e)
         QString s = htable->tipText(col);
 
         if (!s.isEmpty())
-            QToolTip::showText(e->globalPos(), s);
+            QToolTip::showText(e->globalPos(), s, this);
     }
 }
 

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -244,7 +244,7 @@ QString Pstable::tipText(int col)
 
 void Pstable::showTip(QPoint p, int idx)
 {
-    QToolTip::showText(p, tipText(idx));
+    QToolTip::showText(p, tipText(idx), this);
 }
 
 extern TFrame *infobox; // testing


### PR DESCRIPTION
On Wayland, if the widget isn't specified, the instant tooltips of an inactive window might flash and be problematic.

The patch fixes the problem for header tooltips as well as graph tooltips when the window is inactive.