### PR TITLE
Fixed I/O tooltip

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -285,19 +285,20 @@ void msleep(long msec)
 #endif
 }
 
-void mem_string_k(int kbytes, char *buf)
+void mem_string_k(unsigned long kbytes, char *buf)
 {
     if (kbytes >= 1024)
     {
-        int mb = kbytes >> 10;
+        auto mb = kbytes >> 10;
         if (mb >= 1024 * 100)
-            sprintf(buf, "%uGB", mb >> 10);
+            sprintf(buf, "%luGB", mb >> 10);
         else
-            sprintf(buf, "%uMB", mb);
+            sprintf(buf, "%luMB", mb);
     }
     else
-        sprintf(buf, "%uKB", kbytes);
+        sprintf(buf, "%luKB", kbytes);
 }
+
 void mem_string(int kbytes, char *buf)
 {
     if (kbytes >= 1024)

--- a/src/misc.h
+++ b/src/misc.h
@@ -57,7 +57,7 @@ void setQpsTheme();
 int fsize(char *fname);
 void msleep(long msec);
 void mem_string(int kbytes, char *buf);
-void mem_string_k(int kbytes, char *buf);
+void mem_string_k(unsigned long kbytes, char *buf);
 
 void init_xpm();
 void init_misc(QWidget *main);

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -1234,6 +1234,9 @@ Procinfo::Procinfo(Proc *system_proc, int process_id, int thread_id) : refcnt(1)
     io_read = 0;  // **
     io_write = 0; // **
 
+    io_read_KBps = 0;
+    io_write_KBps = 0;
+
     // tgid=0;
     pcpu = 0;
     pmem = 0;


### PR DESCRIPTION
It was populated by senseless numbers because two variables weren't initialized to 0.

The patch fixes the issue and shows processes only when there is real I/O.

Fixes https://github.com/lxqt/qps/issues/408