### PR TITLE
Get rid of c-style strings for users and groups

### DIFF
--- a/src/uidstr.cpp
+++ b/src/uidstr.cpp
@@ -23,56 +23,47 @@
 #include <pwd.h>
 #include <grp.h>
 #include <sys/types.h>
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
 
 #include "uidstr.h"
 
-QHash<int, char *> Uidstr::udict;
-QHash<int, char *> Uidstr::gdict;
+QHash<int, QString> Uidstr::udict;
+QHash<int, QString> Uidstr::gdict;
 
 // return user name (possibly numeric)
-QString Uidstr::userName(int uid)
-{
-    char *p = udict.value(uid, NULL);
-    if (!p)
-    {
-        struct passwd *pw = getpwuid(uid);
-        if (!pw)
-        {
-            p = (char *)malloc(11);
-            sprintf(p, "%d", uid);
-        }
-        else
-            p = strdup(pw->pw_name);
-        udict.insert(uid, p);
-        // if(udict.count() > udict.size() * 3)
-        // udict.resize(udict.count());
+QString Uidstr::userName(int uid) {
+    auto it = udict.find(uid);
+    if (it != udict.end()) {
+        return it.value();
     }
-    QString s(p);
-    return s;
+
+    QString username;
+    struct passwd *pw = getpwuid(uid);
+    if (pw) {
+        username = QString::fromLocal8Bit(pw->pw_name);
+    } else {
+        username = QString::number(uid);
+    }
+
+    udict.insert(uid, username);
+    return username;
 }
 
 // return group name (possibly numeric)
 
-QString Uidstr::groupName(int gid)
-{
-    char *p = gdict[gid];
-    if (!p)
-    {
-        struct group *gr = getgrgid(gid);
-        if (!gr)
-        {
-            p = (char *)malloc(11);
-            sprintf(p, "%d", gid);
-        }
-        else
-            p = strdup(gr->gr_name);
-        gdict.insert(gid, p);
-        // if(gdict.count() > gdict.size() * 3)
-        // gdict.resize(gdict.count());
+QString Uidstr::groupName(int gid) {
+    auto it = gdict.find(gid);
+    if (it != gdict.end()) {
+        return it.value();
     }
-    QString s(p);
-    return s;
+
+    QString groupname;
+    struct group *gr = getgrgid(gid);
+    if (gr) {
+        groupname = QString::fromLocal8Bit(gr->gr_name);
+    } else {
+        groupname = QString::number(gid);
+    }
+
+    gdict.insert(gid, groupname);
+    return groupname;
 }

--- a/src/uidstr.h
+++ b/src/uidstr.h
@@ -33,8 +33,8 @@ class Uidstr
     static QString groupName(int gid);
 
   private:
-    static QHash<int, char *> udict;
-    static QHash<int, char *> gdict;
+    static QHash<int, QString> udict;
+    static QHash<int, QString> gdict;
 };
 
 #endif // UIDSTR_H


### PR DESCRIPTION
This PR updates the `userName` and `groupName` functions in the `Uidstr` class to store `QString`s in the cache instead of C-style strings. The main benefits of this change are:

1. **Improved Readability**: By using `QString`s, we can simplify the code and make it more consistent with modern C++ and Qt coding practices. This makes the code easier to understand and maintain.

2. **Increased Safety**: Storing `QString`s eliminates the need for manual memory management and raw pointers, reducing the risk of memory leaks or other memory-related issues.

3. **Enhanced Performance**: By storing `QString`s directly in the cache, we can eliminate the need for conversion between C-style strings and `QString`s during cache lookups. This reduces the overhead and improves the performance of the cache lookup process.

The updated implementation of the `userName` and `groupName` functions now use `QHash` containers to cache `QString` objects directly, streamlining the cache lookup process and providing the benefits mentioned above.