### PR TITLE
DO NOT MERGE: Normalize and refactor signal-slot connection in Pstable

### DIFF
--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -376,8 +376,7 @@ Pstable::Pstable(QWidget *parent, Procview *pv) : HeadedTable(parent, 0)
 
     connect(this, &HeadedTable::titleClicked, this, &Pstable::setSortColumn);
     connect(this, &HeadedTable::foldSubTree, this, &Pstable::subtree_folded);
-    connect(head, SIGNAL(toolTip(QPoint, int)), this,
-            SLOT(showTip(QPoint, int)));
+    connect(head, &TableHead::toolTip, this, &Pstable::showTip);
     connect(this, &HeadedTable::flyOnCell, this, &Pstable::mouseOnCell );
     connect(this, &HeadedTable::outOfCell, this, &Pstable::mouseOutOfCell);
 }


### PR DESCRIPTION
Original text:
This PR refactors the signal-slot connection in the Pstable class
It's not about old code being an old-style connection, but also about the connection not being normalized as described in https://github.com/KDE/clazy/blob/master/docs/checks/README-connect-not-normalized.md
However, I'm worried that the signal (even after my changes) is overloaded. Crazy emits warning https://github.com/KDE/clazy/blob/master/docs/checks/README-overloaded-signal.md and although the tooltips seem to work I'm unsure if that it works as originally intended 
Text after debugging:
void toolTip(QPoint where, int col); is never emitted in the entire code. I have checked with debugger, breakpoint inside the slot was never triggered, even with tooltips wherever I found them. So, the question is: what is this code