### PR TITLE
Remove overpaintCell

### DIFF
--- a/src/htable.cpp
+++ b/src/htable.cpp
@@ -481,8 +481,6 @@ void TableBody::paintCell(QPainter *p, int row, int col)
 
     p->drawText(gap, 0, w, h, align, htable->text(row, col));
 
-    //htable->overpaintCell(p, row, col, gap); // senseless; Pstable::overpaintCell() should be removed
-
     // cache write!
     attr->text = htable->text(row, col);
     attr->xpos = htable->colXPos(col);

--- a/src/htable.h
+++ b/src/htable.h
@@ -315,7 +315,6 @@ signals:
     virtual bool lastChild(int /*row*/) { return false; }
     virtual bool columnMovable(int /*col*/) { return true; }
     // virtual bool modified(int row){return true;};
-    virtual void overpaintCell(QPainter */*p*/, int /*row*/, int /*col*/, int /*xpos*/){}
 
     void resizeEvent(QResizeEvent *) override;
 

--- a/src/pstable.cpp
+++ b/src/pstable.cpp
@@ -91,53 +91,7 @@ QString Pstable::dragTitle(int col)
     return procview->cats[col]->name;
 }
 
-// TESTING
-void Pstable::overpaintCell(QPainter *p, int row, int col, int xpos)
-{
-    if (col != 0)
-        return;
-    if (procview->cats[col]->id != F_CMD)
-        return;
 
-    int w;
-
-    Procinfo *pi = procview->linear_procs[row];
-
-    int n = pi->nthreads;
-    if (n == 1)
-        return;
-#ifdef LINUX
-    if (pi->pid != pi->tgid)
-        return; // LINUX
-
-#endif
-    w = p->fontMetrics().horizontalAdvance(text(row, col));
-
-    QFont font = p->font();
-    int size = font.pointSize(); // point size
-
-    if (size <= 0)
-        return; // saver!
-
-    int h = body->cellHeight();
-    h = p->fontMetrics().height(); // return pixel
-
-    int msize = h * 3.0 / 8.0;
-    // printf("DEBUG: height=%d, msize=%d\n",h,msize);
-
-    if (h <= 11)
-        return; // saver!
-
-    if (msize < 6)
-        msize = 6;
-
-    // font.setPointSize(msize); // not pixel!
-    font.setPixelSize(msize); // not pixel!
-    p->setFont(font);
-    p->drawText(xpos + w + 2, msize + msize / 3, QString::number(n));
-    font.setPointSize(size);
-    p->setFont(font);
-}
 //
 QString Pstable::text(int row, int col)
 {

--- a/src/pstable.h
+++ b/src/pstable.h
@@ -69,7 +69,6 @@ class Pstable : public HeadedTable
     char *total_selectedRow(int col) override;
     bool columnMovable(int col) override;
 
-    void overpaintCell(QPainter *p, int row, int col, int xpos) override;
     //	virtual bool hasChildren(int row);
 
     void leaveEvent(QEvent *) override;


### PR DESCRIPTION
As mentioned in https://github.com/lxqt/qps/commit/82e7fa8610c573c3e6b4c167fcea065ff01fc612, this function should be removed. It's never used and it triggers a lot of warnings in both clazy and compiler