### PR TITLE
Use MemAvailable

### DIFF
--- a/src/infobar.cpp
+++ b/src/infobar.cpp
@@ -452,8 +452,11 @@ class w_mem : public gwidget
         height = pf_char_height() + 4;
         x = x_cpu->xpluswidth() + 10;
 #ifdef LINUX
-        used = procview->mem_total - procview->mem_free -
-               procview->mem_buffers - procview->mem_cached;
+        if (procview->mem_available != -1) // kernel 3.14+
+            used = procview->mem_total - procview->mem_available;
+        else
+            used = procview->mem_total - procview->mem_free -
+                   procview->mem_buffers - procview->mem_cached;
         width = drawSPECTRUM(p, x, 0, "MEM", procview->mem_total, used,
                              procview->mem_cached, procview->mem_buffers);
 #endif

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -983,6 +983,7 @@ void Proc::commonPostInit()
     Proc::mem_total = 0;
     Proc::mem_free = 0;
 
+    Proc::mem_available = -1;
     Proc::mem_buffers = 0;
     Proc::mem_cached = 0;
 
@@ -1966,6 +1967,8 @@ int Proc::read_system() //
         sscanf(p, "MemTotal: %d kB\n", &mem_total);
     if ((p = strstr(buf, "MemFree:")) != nullptr)
         sscanf(p, "MemFree: %d kB\n", &mem_free);
+    if ((p = strstr(buf, "MemAvailable:")) != nullptr)
+        sscanf(p, "MemAvailable: %d kB\n", &mem_available);
     if ((p = strstr(buf, "Buffers:")) != nullptr)
         sscanf(p, "Buffers: %d kB\n", &mem_buffers);
     if ((p = strstr(buf, "Cached:")) != nullptr)

--- a/src/proc.h
+++ b/src/proc.h
@@ -738,7 +738,7 @@ Q_DECLARE_TR_FUNCTIONS(Proc)
     int mem_total, mem_free;   // (Kb)
     int swap_total, swap_free; // in kB
 
-    int mem_shared, mem_buffers, mem_cached; // Linux
+    int mem_available, mem_shared, mem_buffers, mem_cached; // Linux
 
     // the following are pointers to matrices indexed by kind (above) and
     // cpu


### PR DESCRIPTION
MemAvailable is included in /proc/meminfo since version 3.14 of the kernel; it was added by [commit 34e431b0a](http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0a).

If not found use the old formula.

Closes #472