### PR TITLE
make %MEM = RSS/total mem

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -1635,8 +1635,7 @@ int Procinfo::readproc()
     //	drs		;	// data: wrong in kernel 2.6
     //	dt		;	// zero : in Kernel 2.6
     mem = resident - share;
-    // pmem = 100.0 * resident / proc->mem_total;
-    pmem = 100.0 * mem / proc->mem_total;
+    pmem = 100.0 * resident / proc->mem_total;
 
     // read /proc/PID/status check !!
     if ((buf = read_proc_file2(path, "status")) == nullptr)


### PR DESCRIPTION
It's what the tooltip says it shows and I agree it should (it's what e.g. top does).
The line was already there commented from the beginning (https://github.com/lxqt/qps/blame/fd7837f30ce78e4c9b8b7063124134a7759edcac/src/proc_linux.cpp#L729).