### PR TITLE
Make memory graph tooltip more human-readable

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -305,12 +305,12 @@ void mem_string(int kbytes, char *buf)
     {
         int meg = kbytes >> 10;
         if (meg >= 1024 * 100)
-            sprintf(buf, "%uGb", meg >> 10);
+            sprintf(buf, "%uGiB", meg >> 10);
         else
-            sprintf(buf, "%uMb", meg);
+            sprintf(buf, "%uMiB", meg);
     }
     else
-        sprintf(buf, "%uKb", kbytes);
+        sprintf(buf, "%uKiB", kbytes);
 }
 
 // DEL

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -303,11 +303,11 @@ void mem_string(int kbytes, char *buf)
 {
     if (kbytes >= 1024)
     {
-        int meg = kbytes >> 10;
-        if (meg >= 1024 * 100)
-            sprintf(buf, "%uGiB", meg >> 10);
+        auto meg = kbytes / 1024.0;
+        if (meg >= 1024.0)
+            sprintf(buf, "%.2fGiB", meg / 1024.0);
         else
-            sprintf(buf, "%uMiB", meg);
+            sprintf(buf, "%.0fMiB", meg);
     }
     else
         sprintf(buf, "%uKiB", kbytes);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -305,12 +305,12 @@ void mem_string(int kbytes, char *buf)
     {
         auto meg = kbytes / 1024.0;
         if (meg >= 1024.0)
-            sprintf(buf, "%.2fGiB", meg / 1024.0);
+            sprintf(buf, "%.2f GiB", meg / 1024.0);
         else
-            sprintf(buf, "%.0fMiB", meg);
+            sprintf(buf, "%.0f MiB", meg);
     }
     else
-        sprintf(buf, "%uKiB", kbytes);
+        sprintf(buf, "%u KiB", kbytes);
 }
 
 // DEL


### PR DESCRIPTION
Display binary prefixes (MiB, GiB).
Before it would only switch from MiB to GiB at 100 GiB. Now it switches at 1 GiB, and shows two decimals:
![screenshot-1a72f24f](https://github.com/lxqt/qps/assets/125407598/9d71f95e-1fa6-471e-b6e4-96055c449481)
I took the liberty of adding a space between the number and the unit because it makes it easier to read and we are not space constrained in the tooltip.

fixes #215