### PR TITLE
Fix screenshot URL

### DIFF
--- a/org.lxqt.Qps.appdata.xml
+++ b/org.lxqt.Qps.appdata.xml
@@ -22,7 +22,7 @@
    <url type="homepage">https://github.com/lxqt/qps/</url>
    <screenshots>
       <screenshot type="default">
-         <image>https://github.com/lxqt/qps/blob/master/qps.png</image>
+         <image>https://github.com/lxqt/qps/raw/master/qps.png</image>
       </screenshot>
    </screenshots>
 </component>


### PR DESCRIPTION
It should be the raw image, not the web page containing the image.